### PR TITLE
[#5] Create GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/lab_task.yml
+++ b/.github/ISSUE_TEMPLATE/lab_task.yml
@@ -1,0 +1,70 @@
+name: Lab or Workflow Task
+description: Track one independently reviewable unit of work.
+title: "[Task]: "
+labels:
+  - lab
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use one issue per branch and one branch per pull request.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should this task accomplish?
+      placeholder: Add a focused, testable outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What files, components, or behavior are in scope?
+      placeholder: List the expected work and explicit non-goals.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true before this issue can close?
+      placeholder: |
+        - The feature does X.
+        - The docs explain Y.
+        - The command Z passes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation Plan
+      description: Which tests, builds, or smoke checks should prove the work?
+      placeholder: |
+        - Run `git diff --check`.
+        - Run the relevant unit tests.
+        - Run a documented smoke test.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies or Blockers
+      description: List any prerequisite issues, approvals, or external setup.
+      placeholder: None.
+    validations:
+      required: false
+
+  - type: input
+    id: branch
+    attributes:
+      label: Expected Branch
+      description: Use `issue-<number>-short-description` after the issue is created.
+      placeholder: issue-123-short-description
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+Describe the change in one or two short paragraphs.
+
+## Linked Issue
+
+Closes #
+
+## Workflow Checklist
+
+- [ ] This PR has a linked GitHub issue.
+- [ ] This branch is dedicated to one issue.
+- [ ] This PR does not include unrelated work.
+- [ ] The branch has been pushed to GitHub.
+
+## Changes
+
+- List the user-visible or repo-visible changes.
+
+## Validation
+
+List the exact commands or checks run.
+
+- List each command and result.
+
+## Known Limitations / Follow-Up
+
+List any intentionally deferred work or follow-up issues.
+
+- Link follow-up issues or write `None`.


### PR DESCRIPTION
## Summary

Adds GitHub issue and pull request templates that reinforce the repository's issue-first workflow.

## Changes

- Adds `.github/ISSUE_TEMPLATE/lab_task.yml` for one-issue-per-branch lab/workflow tasks.
- Adds `.github/pull_request_template.md` requiring linked issues, workflow confirmation, change summary, validation, and follow-up notes.

Closes #5

## Validation

- `git diff --cached --check` passed before commit.
- Template contents were reviewed manually.

## Known Limitations

- Local YAML parser validation could not be run: Ruby's YAML parser is missing `libyaml`, and Python does not have `PyYAML` installed in this environment.