### PR TITLE
[#15] Pin Pages build to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install, build, and upload
         uses: withastro/action@v3
+        with:
+          node-version: 22
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

Pins the GitHub Pages Astro build to Node 22 after the Astro 6 upgrade.

## Changes

- Adds `node-version: 22` to the `withastro/action@v3` build step in `.github/workflows/deploy.yml`.

Closes #15

## Validation

- `node --version` -> `v22.17.0`
- `asdf current nodejs` -> `nodejs 22.17.0 /Users/jaegerpicker/.tool-versions true`
- `asdf set -u nodejs 22.17.0` completed successfully, re-asserting Node 22 as the global asdf default.
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` passed locally under Node 22.
- `act -j build --container-architecture linux/amd64 -P ubuntu-latest=catthehacker/ubuntu:act-latest` was run locally. It installed Node `v22.22.2`, ran `npm install`, and completed `astro build` successfully. The local act job then failed at `actions/upload-artifact` because `ACTIONS_RUNTIME_TOKEN` is unavailable in local act runs.
- `git diff --check` passed.

## Known Limitations / Follow-Up

- The full Pages artifact upload/deploy path cannot be completed locally with this `act` run because GitHub's artifact runtime token is only present in GitHub Actions.