### PR TITLE
[#22] Update Pages actions for Node 24 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install, build, and upload
-        uses: withastro/action@v3
+        uses: withastro/action@v6
         with:
           node-version: 22
 


### PR DESCRIPTION
Closes #22

## Summary
- Update the Pages build checkout step from actions/checkout@v4 to actions/checkout@v6.
- Update the Astro Pages build action from withastro/action@v3 to withastro/action@v6.
- Keep the Astro project build runtime pinned to Node 22 with node-version: 22.

## Validation
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check
- rg confirmed the workflow no longer references actions/checkout@v4 or withastro/action@v3
- act -j build attempted locally; it reached the updated actions but failed in the local Docker/act environment with EROFS/no-space-left-on-device errors, not an Astro build or workflow syntax failure.

## Known limitations
- actions/deploy-pages remains at v4 because current GitHub and Astro Pages docs still show deploy-pages@v4 for this workflow path.