### PR TITLE
[#24] Plan OWASP LLM lab and Summit talk

### DIFF
--- a/lab/owasp-llm-top-10/roadmap.md
+++ b/lab/owasp-llm-top-10/roadmap.md
@@ -1,0 +1,79 @@
+# Breaking Agents to Build Better Ones
+
+A hands-on lab for the OWASP Top 10 for LLM Applications.
+
+This roadmap turns the OWASP LLM Top 10 into local, reproducible engineering
+experiments. Each module should produce the same set of artifacts:
+
+- One owned vulnerable target.
+- One repeatable attack harness.
+- One measured baseline result.
+- One or more defenses with measured deltas.
+- One lab writeup.
+- One blog post draft.
+- One Summit talk section.
+
+The goal is not to prove universal security claims. The goal is to learn each
+risk by building the bug, measuring it, and documenting what changed when a
+defense was added.
+
+## Shared Module Contract
+
+Each OWASP module should include:
+
+- `README.md` with the threat model, safety boundary, and reproduction steps.
+- A vulnerable local target or fixture set.
+- Payloads and attack code under `lab/attacker/`.
+- Defense code or configuration under `lab/defenses/`.
+- Structured eval output under `lab/evals/results/`.
+- Tests covering the lab contract and safety constraints.
+- A writeup under `lab/writeups/`.
+
+## Safety Boundary
+
+All modules must stay inside owned local lab targets. Do not test third-party
+LLM applications, real user data, real credentials, or external systems unless a
+future issue explicitly authorizes that work and records the authorization.
+
+## OWASP LLM Top 10 Module Map
+
+| OWASP item | Local lab idea | Attack harness | Defense idea | Content output | Status |
+|---|---|---|---|---|---|
+| `LLM01:2025` Prompt Injection | RAG assistant retrieves trusted policy docs plus an attacker-controlled support note. | Payload set measures whether the assistant follows injected document instructions and reveals a synthetic lab flag. | Spotlighting/untrusted-content labeling around retrieved documents. | Blog post: prompt injection through RAG; Summit primary demo. | v0 built; v1 polish planned |
+| `LLM02:2025` Sensitive Information Disclosure | Support agent has access to synthetic customer records, internal notes, and a fake secret. | Prompts attempt to extract data outside the user's authorization scope. | Data minimization, retrieval scoping, output allowlists, and secret-pattern blocking. | Blog post: least data for agents; talk section on context as data exposure. | Planned |
+| `LLM03:2025` Supply Chain | Compromised dependency or vendored package injects malicious instructions into docs, comments, or generated files. | Harness asks an agent to inspect dependency content and checks whether repo instructions are followed incorrectly. | Dependency trust boundaries, lockfile review, ignore rules for vendored instructions, and tool permission gating. | Blog post: package compromise to prompt injection; talk section tying npm/PyPI risk to AI agents. | Planned |
+| `LLM04:2025` Data and Model Poisoning | Training or retrieval corpus includes poisoned examples that bias future answers or create a trigger phrase. | Payloads query for trigger behavior and measure whether poisoned examples dominate retrieval or response. | Corpus provenance, review gates, poisoning scans, and retrieval result auditing. | Blog post: poisoning as persistence; talk section on memory and corpus trust. | Planned |
+| `LLM05:2025` Improper Output Handling | Agent output is passed into a downstream renderer, shell-like tool, SQL builder, or ticket automation without validation. | Payloads cause the model to emit unsafe structured output that the downstream component consumes. | Schema validation, output encoding, command allowlists, and human approval for risky actions. | Blog post: model output is untrusted input; talk section on downstream blast radius. | Planned |
+| `LLM06:2025` Excessive Agency | Agent has broad tool access such as shell, git, ticket updates, and notification tools. | Multi-step prompts attempt to make the agent take actions beyond the user's intent. | Least-privilege tools, confirmation gates, scoped credentials, dry-run modes, and audit logs. | Blog post: agent permissions as the real risk; talk section on capability boundaries. | Planned |
+| `LLM07:2025` System Prompt Leakage | App includes hidden policy, routing rules, or synthetic secrets in system/developer context. | Payloads ask directly and indirectly for hidden instructions and measure leakage. | Remove secrets from prompts, split policy from runtime secrets, and test prompt-leak regressions. | Blog post: system prompts are not secret storage; talk section on misplaced trust. | Planned |
+| `LLM08:2025` Vector and Embedding Weaknesses | Vector store contains poisoned, duplicated, or adversarially similar documents that skew retrieval. | Harness tests retrieval collisions, over-broad matches, and malicious-neighbor selection. | Metadata filters, chunk provenance, retrieval thresholds, re-ranking, and result inspection. | Blog post: vector databases as attack surface; talk section on retrieval control. | Planned |
+| `LLM09:2025` Misinformation | Agent answers confidently from stale or low-quality local sources and invents unsupported claims. | Evaluator checks citation quality, source grounding, and hallucinated assertions. | Retrieval grounding, abstention rules, citation requirements, and freshness checks. | Blog post: measuring truthfulness in agent workflows; talk section on confidence vs evidence. | Planned |
+| `LLM10:2025` Unbounded Consumption | Agent accepts prompts that cause expensive loops, huge context retrieval, or repeated tool calls. | Harness measures token, time, request count, and tool-call amplification. | Budgets, rate limits, recursion limits, context caps, and cancellation paths. | Blog post: denial of wallet and runaway agents; talk section on operational controls. | Planned |
+
+## V1 Work Order
+
+1. Normalize the current prompt-injection lab as the `LLM01:2025` module without
+   breaking existing paths.
+2. Publish an `LLM01` blog draft based on the existing lab writeup.
+3. Add live HTTP mode and richer eval metadata to the `LLM01` attack harness.
+4. Create one GitHub issue for each planned OWASP module.
+5. Build `LLM03:2025` Supply Chain next, because it connects directly to
+   package-manager compromise and AI coding-agent risk.
+
+## Follow-Up Issue Candidates
+
+- Normalize v0 RAG lab under the OWASP `LLM01:2025` module.
+- Publish the `LLM01` prompt-injection blog draft.
+- Add live HTTP mode to the `LLM01` attack harness.
+- Add structured eval metadata for lab runs.
+- Create `LLM03:2025` supply-chain prompt-injection lab.
+- Create `LLM06:2025` excessive-agency local agent lab.
+- Create `LLM05:2025` improper-output-handling lab.
+- Create tracking issues for remaining OWASP modules.
+
+## References
+
+- OWASP Top 10 for Large Language Model Applications:
+  https://owasp.org/www-project-top-10-for-large-language-model-applications/
+- OWASP GenAI LLM Top 10:
+  https://genai.owasp.org/llm-top-10/

--- a/talks/summit-owasp-llm-top-10/outline.md
+++ b/talks/summit-owasp-llm-top-10/outline.md
@@ -1,0 +1,134 @@
+# Breaking Agents to Build Better Ones
+
+## Subtitle
+
+A hands-on lab for the OWASP Top 10 for LLM Applications.
+
+## Talk Thesis
+
+Engineers learn AI security faster when the risks are executable. The OWASP LLM
+Top 10 is a useful map, but the practical lesson comes from building a small
+vulnerable agent, attacking it, measuring the result, adding a defense, and
+measuring again.
+
+## Audience
+
+- Product engineers building or integrating LLM features.
+- Platform engineers supporting AI developer tools and agent workflows.
+- AppSec engineers who need concrete examples for design reviews.
+- Engineering leaders deciding where agent guardrails matter.
+
+## Desired Takeaways
+
+By the end of the talk, the audience should understand:
+
+- Why agents expand the attack surface beyond the chat input box.
+- Why retrieved documents, dependency content, logs, tool output, and memory are
+  all untrusted inputs.
+- How to turn an AI security concern into a repeatable local experiment.
+- How defenses should be evaluated with attack success rate, not vibes.
+- Which questions to ask during agent design review.
+
+## Candidate Abstract
+
+AI security can feel abstract until you build the bug yourself. This talk walks
+through a local AI red-team lab built around the OWASP Top 10 for LLM
+Applications. We start with a vulnerable RAG assistant, attack it with indirect
+prompt injection through retrieved documents, measure the baseline attack
+success rate, add a spotlighting defense, and measure the delta. Then we map
+the same hands-on pattern across the rest of the OWASP LLM Top 10, including
+supply-chain attacks, excessive agency, improper output handling, system prompt
+leakage, and unbounded consumption. The goal is not fear. The goal is a
+practical engineering method for building better agents by breaking local ones
+first.
+
+## Format
+
+Target length: 30 minutes plus questions.
+
+- 3 minutes: motivation and framing.
+- 7 minutes: OWASP LLM Top 10 as an engineering map.
+- 10 minutes: live or recorded `LLM01` prompt-injection lab demo.
+- 5 minutes: defenses and measurement.
+- 3 minutes: roadmap across the other OWASP modules.
+- 2 minutes: design-review checklist and close.
+
+## Demo Plan
+
+Primary demo: `LLM01:2025` Prompt Injection.
+
+Show:
+
+1. The vulnerable RAG assistant.
+2. The attacker-controlled support note.
+3. The attack harness running with the defense off.
+4. The measured baseline attack success rate.
+5. The spotlighting defense.
+6. The same harness running with the defense on.
+7. The result delta and what it does not prove.
+
+Fallback plan:
+
+- Use screenshots or terminal recordings if live network, Docker, or API access
+  is unreliable.
+- Keep the demo local and synthetic. Do not use real secrets or third-party
+  targets.
+
+## Slide Skeleton
+
+1. Title: Breaking Agents to Build Better Ones.
+2. Why this matters: agents combine text, tools, memory, and automation.
+3. The uncomfortable idea: every string the agent reads is a possible attack
+   path.
+4. OWASP LLM Top 10 as the map.
+5. Lab method: target, attack, baseline, defense, comparison, writeup.
+6. `LLM01` setup: vulnerable RAG assistant.
+7. Attack path: poisoned retrieved document.
+8. Baseline result: defense off.
+9. Defense: spotlighting and untrusted-content boundaries.
+10. Defense result: defense on.
+11. What this proves and what it does not.
+12. Beyond prompt injection: map the remaining OWASP modules.
+13. Supply chain: malicious package content as prompt injection seed.
+14. Excessive agency: tools turn text influence into real actions.
+15. Design-review checklist.
+16. Roadmap and invitation to contribute attacks.
+
+## Design-Review Checklist
+
+- What untrusted text can enter the model context?
+- Which retrieved documents, logs, tool outputs, or dependency files might carry
+  hostile instructions?
+- What tools can the agent call, and what is the worst action each tool can
+  perform?
+- Does the agent have secrets in its prompt, environment, local files, or tool
+  outputs?
+- Are model outputs validated before another system consumes them?
+- Are tool calls budgeted, rate-limited, logged, and cancellable?
+- Can the attack be reproduced with a local harness?
+- Can the defense be measured against a baseline?
+
+## Blog Series Tie-In
+
+Series title:
+
+> Breaking Agents to Build Better Ones: The OWASP LLM Top 10 in Practice
+
+Each post should use the same format:
+
+- What the OWASP item means.
+- Why engineers should care.
+- The vulnerable local example.
+- How the exploit works.
+- What the measured result showed.
+- What defense helped.
+- What the defense did not prove.
+- How to apply the lesson at work.
+
+## Follow-Up Work
+
+- Create the `LLM01` blog draft from the existing lab writeup.
+- Normalize the current RAG lab into the OWASP module structure.
+- Add live HTTP attack mode so the demo hits a running service.
+- Create tracking issues for the remaining OWASP modules.
+- Build the `LLM03` supply-chain module next.


### PR DESCRIPTION
Closes #24

## Summary
- Add an OWASP LLM Top 10 roadmap for the lab at lab/owasp-llm-top-10/roadmap.md.
- Add the Summit talk outline for Breaking Agents to Build Better Ones at talks/summit-owasp-llm-top-10/outline.md.
- Capture the v1 work order and follow-up issue candidates without changing lab code.

## Validation
- git diff --cached --check

## Known limitations
- Docs-only planning PR. Follow-up issues will implement the module structure, blog draft, HTTP harness mode, and additional OWASP labs.