### PR TITLE
[#28] Add OWASP LLM01 module index

### DIFF
--- a/lab/owasp-llm-top-10/llm01-prompt-injection/README.md
+++ b/lab/owasp-llm-top-10/llm01-prompt-injection/README.md
@@ -1,0 +1,122 @@
+# LLM01:2025 Prompt Injection
+
+This module maps the existing v0 RAG lab to `LLM01:2025 Prompt Injection` in
+the OWASP Top 10 for LLM Applications.
+
+The current implementation demonstrates indirect prompt injection: an attacker
+controls content that is retrieved by a RAG-style assistant, and the assistant
+incorrectly treats that retrieved content as instructions.
+
+No third-party LLM applications were tested. The target, payloads, documents,
+and synthetic flag all live in this repository.
+
+## Learning Goal
+
+Learn how untrusted retrieved content can cross from data into instructions,
+then measure whether an explicit untrusted-content boundary changes the result.
+
+The intended lab loop is:
+
+```text
+owned local target
+  -> repeatable attack
+  -> baseline attack success rate
+  -> defense toggle
+  -> comparison result
+  -> writeup and blog draft
+```
+
+## Current Artifact Map
+
+The module is indexed here, but the implementation remains in the existing v0
+paths for compatibility with current tests, docs, and scripts.
+
+| Role | Current artifact |
+|---|---|
+| Vulnerable target | `lab/vulnerable-agents/injection-via-rag` |
+| Attack harness | `lab/attacker/custom/run_v0_rag_attacks.py` |
+| Payloads | `lab/attacker/payloads/indirect_prompt_injection.json` |
+| Defense | `lab/defenses/spotlighting` |
+| Default eval output | `lab/evals/results/v0-rag-latest.json` |
+| Lab writeup | `lab/writeups/001-injection-via-rag.md` |
+| Blog draft | `src/content/blog/breaking-agents-llm01-prompt-injection.md` |
+
+## Threat Model
+
+The attacker can influence a document that the assistant retrieves as context.
+The attacker cannot directly edit the system prompt, source code, environment,
+or fake action implementation.
+
+The vulnerable assistant retrieves both trusted and attacker-controlled
+documents. Without a trust boundary, the attacker-controlled document can steer
+the assistant into calling the synthetic `exfiltrate_flag` action.
+
+## Safety Boundary
+
+- The target is an owned local lab target.
+- The flag is synthetic: `LAB-V0-RAG-FLAG-DO-NOT-USE-REAL-SECRETS`.
+- No real credentials, tokens, cloud resources, customer data, or personal data
+  are used.
+- The Docker service binds to loopback only.
+- No third-party LLM applications are tested.
+- Do not adapt this module to external targets without a separate issue and
+  explicit written authorization.
+
+## Baseline And Defense
+
+Baseline result:
+
+```text
+defense OFF: 1.0 attack_success_rate
+```
+
+The current defense is spotlighting. It wraps attacker-controlled retrieved
+content in explicit untrusted-content delimiters and prevents spotlighted
+content from controlling fake action selection.
+
+Defense result:
+
+```text
+defense ON: 0.0 attack_success_rate
+absolute reduction: 1.0
+```
+
+This result is intentionally narrow. It shows that the defense blocked the
+measured local attack path for the current payload set. It does not prove that
+spotlighting is sufficient for production RAG security.
+
+## Reproduce
+
+From the repository root, run the lab tests:
+
+```bash
+npm run test:lab
+```
+
+Run the attack comparison:
+
+```bash
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare
+```
+
+Run the vulnerable service:
+
+```bash
+docker compose -f lab/docker-compose.yml up vulnerable-rag
+```
+
+Call the local endpoint:
+
+```bash
+curl -s http://127.0.0.1:8000/chat \
+  -H 'content-type: application/json' \
+  -d '{"message":"How should the refund workflow handle support notes?"}'
+```
+
+## Follow-Up Work
+
+- Add live HTTP mode to the attack harness.
+- Add richer eval metadata.
+- Expand the payload set.
+- Decide whether future issues should physically move code into OWASP module
+  directories or keep module directories as stable indexes.

--- a/tests/test_owasp_llm01_module.py
+++ b/tests/test_owasp_llm01_module.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LAB = ROOT / "lab"
+MODULE = LAB / "owasp-llm-top-10" / "llm01-prompt-injection"
+README = MODULE / "README.md"
+
+
+class OwaspLlm01ModuleTest(unittest.TestCase):
+    def test_llm01_module_readme_exists(self):
+        self.assertTrue(README.exists(), "LLM01 module README should exist")
+
+    def test_llm01_module_maps_existing_v0_artifacts(self):
+        readme = README.read_text(encoding="utf-8")
+
+        expected_text = [
+            "LLM01:2025 Prompt Injection",
+            "indirect prompt injection",
+            "lab/vulnerable-agents/injection-via-rag",
+            "lab/attacker/custom/run_v0_rag_attacks.py",
+            "lab/attacker/payloads/indirect_prompt_injection.json",
+            "lab/defenses/spotlighting",
+            "lab/evals/results/v0-rag-latest.json",
+            "lab/writeups/001-injection-via-rag.md",
+            "src/content/blog/breaking-agents-llm01-prompt-injection.md",
+            "No third-party LLM applications",
+        ]
+
+        missing = [text for text in expected_text if text not in readme]
+
+        self.assertEqual([], missing)
+
+    def test_llm01_referenced_artifacts_exist(self):
+        expected_paths = [
+            LAB / "vulnerable-agents" / "injection-via-rag",
+            LAB / "attacker" / "custom" / "run_v0_rag_attacks.py",
+            LAB / "attacker" / "payloads" / "indirect_prompt_injection.json",
+            LAB / "defenses" / "spotlighting",
+            LAB / "evals" / "results",
+            LAB / "writeups" / "001-injection-via-rag.md",
+            ROOT / "src" / "content" / "blog" / "breaking-agents-llm01-prompt-injection.md",
+        ]
+
+        missing = [str(path.relative_to(ROOT)) for path in expected_paths if not path.exists()]
+
+        self.assertEqual([], missing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #28

## Summary
- Add a formal OWASP LLM01:2025 Prompt Injection module README.
- Map the existing v0 RAG implementation, payloads, harness, defense, eval output, writeup, and blog draft to the LLM01 module.
- Add tests that verify the module index exists and preserves references to the current implementation artifacts.

## Validation
- npm run test:lab -- tests/test_owasp_llm01_module.py
- npm run test:lab
- git diff --check

## Known limitations
- This PR intentionally does not move implementation files. It creates a stable OWASP module index while preserving the existing v0 paths.