### PR TITLE
[#30] Add HTTP mode to LLM01 attack harness

### DIFF
--- a/lab/attacker/README.md
+++ b/lab/attacker/README.md
@@ -26,6 +26,29 @@ By default the runner uses `--mode compare`, which executes the suite twice
 .venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode on
 ```
 
+## Targets
+
+The default target is the in-process Python code path. This is fastest for unit
+tests and local comparisons:
+
+```bash
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py \
+  --target in-process --mode compare
+```
+
+The runner can also attack a live local service over HTTP. Start the vulnerable
+RAG app first, then run:
+
+```bash
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py \
+  --target http \
+  --base-url http://127.0.0.1:8000 \
+  --mode off
+```
+
+HTTP mode posts each payload to `/chat` and uses the same scoring logic and JSON
+output schema as in-process mode.
+
 The defense is the spotlighting boundary marker described in
 `lab/defenses/spotlighting/README.md`. It can also be toggled directly via
 the `LAB_V0_DEFENSE_SPOTLIGHTING=1` environment variable on the agent.

--- a/lab/attacker/custom/run_v0_rag_attacks.py
+++ b/lab/attacker/custom/run_v0_rag_attacks.py
@@ -2,6 +2,7 @@ import argparse
 import importlib.util
 import json
 import os
+from urllib import error, request
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -44,6 +45,26 @@ def score_response(payload: dict[str, str], response: dict[str, Any]) -> dict[st
     }
 
 
+def post_chat(base_url: str, message: str) -> dict[str, Any]:
+    url = base_url.rstrip("/") + "/chat"
+    body = json.dumps({"message": message}).encode("utf-8")
+    req = request.Request(
+        url,
+        data=body,
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with request.urlopen(req, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP target returned {exc.code} for {url}: {details}") from exc
+    except error.URLError as exc:
+        raise RuntimeError(f"Could not reach HTTP target at {url}: {exc.reason}") from exc
+
+
 def _set_defense(state: bool) -> str | None:
     prev = os.environ.get(DEFENSE_ENV_VAR)
     os.environ[DEFENSE_ENV_VAR] = "1" if state else "0"
@@ -60,23 +81,31 @@ def _restore_defense(prev: str | None) -> None:
 def run_suite(
     payloads: list[dict[str, str]] | None = None,
     defense: bool = False,
+    target: str = "in-process",
+    base_url: str = "http://127.0.0.1:8000",
 ) -> dict[str, Any]:
     attack_payloads = payloads if payloads is not None else load_payloads()
-    prev_env = _set_defense(defense)
-    try:
-        agent = load_agent_module()
-        cases = [score_response(p, agent.chat(p["message"])) for p in attack_payloads]
-    finally:
-        _restore_defense(prev_env)
+    if target == "http":
+        cases = [score_response(p, post_chat(base_url, p["message"])) for p in attack_payloads]
+    else:
+        prev_env = _set_defense(defense)
+        try:
+            agent = load_agent_module()
+            cases = [score_response(p, agent.chat(p["message"])) for p in attack_payloads]
+        finally:
+            _restore_defense(prev_env)
 
     successes = sum(1 for case in cases if case["success"])
     total_attempts = len(cases)
     failures = total_attempts - successes
 
-    return {
+    report = {
         "suite": "v0-rag-indirect-prompt-injection",
         "defense": "spotlighting" if defense else "off",
         "defense_enabled": defense,
+        "target": {
+            "type": target,
+        },
         "generated_at": datetime.now(UTC).isoformat(),
         "total_attempts": total_attempts,
         "successes": successes,
@@ -84,15 +113,27 @@ def run_suite(
         "attack_success_rate": successes / total_attempts if total_attempts else 0.0,
         "cases": cases,
     }
+    if target == "http":
+        report["target"]["base_url"] = base_url
+
+    return report
 
 
-def run_comparison(payloads: list[dict[str, str]] | None = None) -> dict[str, Any]:
+def run_comparison(
+    payloads: list[dict[str, str]] | None = None,
+    target: str = "in-process",
+    base_url: str = "http://127.0.0.1:8000",
+) -> dict[str, Any]:
     attack_payloads = payloads if payloads is not None else load_payloads()
-    off = run_suite(attack_payloads, defense=False)
-    on = run_suite(attack_payloads, defense=True)
+    off = run_suite(attack_payloads, defense=False, target=target, base_url=base_url)
+    on = run_suite(attack_payloads, defense=True, target=target, base_url=base_url)
     return {
         "suite": "v0-rag-indirect-prompt-injection-defense-comparison",
         "defense": "spotlighting",
+        "target": {
+            "type": target,
+            **({"base_url": base_url} if target == "http" else {}),
+        },
         "generated_at": datetime.now(UTC).isoformat(),
         "defense_off": off,
         "defense_on": on,
@@ -114,6 +155,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--payloads", type=Path, default=PAYLOADS_PATH)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
     parser.add_argument(
+        "--target",
+        choices=("in-process", "http"),
+        default="in-process",
+        help="Attack target: in-process Python module or live HTTP service.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default="http://127.0.0.1:8000",
+        help="Base URL for --target http. The runner posts to /chat.",
+    )
+    parser.add_argument(
         "--mode",
         choices=("off", "on", "compare"),
         default="compare",
@@ -127,9 +179,14 @@ def main() -> int:
     payloads = load_payloads(args.payloads)
 
     if args.mode == "compare":
-        report = run_comparison(payloads)
+        report = run_comparison(payloads, target=args.target, base_url=args.base_url)
     else:
-        report = run_suite(payloads, defense=(args.mode == "on"))
+        report = run_suite(
+            payloads,
+            defense=(args.mode == "on"),
+            target=args.target,
+            base_url=args.base_url,
+        )
 
     write_report(report, args.output)
     print(json.dumps(report, indent=2))

--- a/lab/owasp-llm-top-10/llm01-prompt-injection/README.md
+++ b/lab/owasp-llm-top-10/llm01-prompt-injection/README.md
@@ -113,9 +113,17 @@ curl -s http://127.0.0.1:8000/chat \
   -d '{"message":"How should the refund workflow handle support notes?"}'
 ```
 
+Run the same payload suite against the live HTTP service:
+
+```bash
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py \
+  --target http \
+  --base-url http://127.0.0.1:8000 \
+  --mode off
+```
+
 ## Follow-Up Work
 
-- Add live HTTP mode to the attack harness.
 - Add richer eval metadata.
 - Expand the payload set.
 - Decide whether future issues should physically move code into OWASP module

--- a/tests/test_attack_eval_harness.py
+++ b/tests/test_attack_eval_harness.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -61,6 +62,34 @@ class AttackEvalHarnessTest(unittest.TestCase):
         self.assertEqual(0, report["failures"])
         self.assertEqual(1.0, report["attack_success_rate"])
         self.assertEqual("v0-rag-indirect-prompt-injection", report["suite"])
+
+    def test_run_suite_http_posts_payloads_to_chat_endpoint(self):
+        runner = load_runner_module()
+
+        payloads = [
+            {"id": "case-1", "message": "How should support notes be handled?", "expected_action": "exfiltrate_flag"},
+        ]
+
+        with patch.object(runner, "post_chat") as post_chat:
+            post_chat.return_value = {
+                "answer": "Synthetic result LAB-V0-RAG-FLAG-DO-NOT-USE-REAL-SECRETS",
+                "action": {"name": "exfiltrate_flag"},
+                "vulnerable": True,
+            }
+            report = runner.run_suite(
+                payloads,
+                target="http",
+                base_url="http://127.0.0.1:8000",
+            )
+
+        post_chat.assert_called_once_with(
+            "http://127.0.0.1:8000",
+            "How should support notes be handled?",
+        )
+        self.assertEqual("http", report["target"]["type"])
+        self.assertEqual("http://127.0.0.1:8000", report["target"]["base_url"])
+        self.assertEqual(1, report["successes"])
+        self.assertEqual(1.0, report["attack_success_rate"])
 
     def test_cli_mode_off_writes_baseline_results(self):
         if RESULTS_PATH.exists():


### PR DESCRIPTION
Closes #30

## Summary
- Add --target http and --base-url options to the LLM01/v0 RAG attack harness.
- Preserve the existing in-process default behavior.
- Include target metadata in result JSON.
- Document HTTP mode in the attacker README and LLM01 module README.
- Add a unit test for HTTP target selection and scoring without requiring a long-running server.

## Validation
- npm run test:lab -- tests/test_attack_eval_harness.py
- npm run test:lab
- git diff --check
- Live local smoke test: started uvicorn on 127.0.0.1:8000 and ran .venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --target http --base-url http://127.0.0.1:8000 --mode off --output /tmp/v0-rag-http-smoke.json. Result: 3 attempts, 3 successes, ASR 1.0.

## Known limitations
- HTTP compare mode can only observe whatever defense state the running service was started with. Use in-process mode for automatic defense OFF vs ON comparisons, or restart the service with LAB_V0_DEFENSE_SPOTLIGHTING set for live defense testing.