### PR TITLE
[#57] Fix custom-domain base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 Personal blog and research notes on AI security, red teaming, and agentic
 systems. Built with [Astro](https://astro.build) and deployed to GitHub Pages.
 
-Live site: <https://jaegerpicker.github.io/ai_sec_research/>
+Live site: <https://sandkcampbell.com/>
 
 ## Local development
 
 ```bash
 npm install
-npm run dev       # http://localhost:4321/ai_sec_research/
+npm run dev       # http://localhost:4321/
 npm run build
 npm run preview
 ```

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,11 +2,9 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
-// Deploy target: https://jaegerpicker.github.io/ai_sec_research
-// If you later move to a custom domain, set `site` to that domain and remove `base`.
+// Deploy target: https://sandkcampbell.com
 export default defineConfig({
-  site: 'https://jaegerpicker.github.io',
-  base: '/ai_sec_research',
+  site: 'https://sandkcampbell.com',
   trailingSlash: 'ignore',
   integrations: [mdx(), sitemap()],
   markdown: {


### PR DESCRIPTION
Closes #57

## Summary
- Point Astro site at https://sandkcampbell.com.
- Remove the GitHub project-page base so generated routes and links live at the custom-domain root.
- Update README live and local dev URLs.

## Validation
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check
- Inspected generated dist output for stale /ai_sec_research project-page links and confirmed /blog/welcome links plus sandkcampbell.com/blog/welcome/ canonical/OG URLs.

## Known limitations
- The old https://sandkcampbell.com/ai_sec_research/blog/welcome path is expected to stop being the canonical path; after deploy the valid URL is https://sandkcampbell.com/blog/welcome.