### PR TITLE
[#64] Fix resume page width override

### DIFF
--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -278,7 +278,7 @@ const signals = [
     color: #d9e4ea;
   }
 
-  :global(main) {
+  :global(body main) {
     width: min(1180px, calc(100% - 2rem));
     max-width: none;
   }
@@ -582,23 +582,29 @@ const signals = [
     text-decoration: none;
   }
 
-  @media (max-width: 860px) {
-    :global(main) {
-      width: min(100% - 1rem, 1180px);
-    }
-
+  @media (max-width: 1100px) {
     .hero-panel,
     .role-header {
       grid-template-columns: 1fr;
     }
 
-    .capability-grid,
-    .signals-grid {
-      grid-template-columns: 1fr;
+    .hero-panel::after {
+      opacity: 0.45;
     }
 
     .role-header span {
       text-align: left;
+    }
+  }
+
+  @media (max-width: 860px) {
+    :global(body main) {
+      width: min(100% - 1rem, 1180px);
+    }
+
+    .capability-grid,
+    .signals-grid {
+      grid-template-columns: 1fr;
     }
   }
 </style>


### PR DESCRIPTION
Closes #64

## Summary
- Strengthen the resume route `main` width override to `body main` so it beats the global 720px rule in production CSS order.
- Stack the hero telemetry panel at medium widths to prevent the title from colliding with the telemetry box.

## Validation
- ASTRO_TELEMETRY_DISABLED=1 npm run build
- git diff --check
- rg -n "<private-street-address>|<private-phone>|<private-email>" docs src dist after substituting the private PDF values locally; no matches
- Built CSS inspection confirms `body main` and the `max-width: 1100px` hero stack breakpoint.

## Known limitations
- This only fixes the resume page width issue; broader site theme migration remains deferred.