### PR TITLE
[#72] Design OWASP lab presentation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ tags: ["..."]          # optional
 ---
 ```
 
+## Presentation package
+
+The accepted OWASP LLM Top 10 lab talk lives in
+`talks/summit-owasp-llm-top-10/`.
+
+- Repo-native slide source: `talks/summit-owasp-llm-top-10/slides.md`
+- Speaker notes: `talks/summit-owasp-llm-top-10/speaker-notes.md`
+- Demo runbook: `talks/summit-owasp-llm-top-10/demo-runbook.md`
+- Public web version after deploy:
+  <https://sandkcampbell.com/talks/summit-owasp-llm-top-10/>
+
 ## Deployment
 
 GitHub Actions (`.github/workflows/deploy.yml`) builds and deploys on every
@@ -40,13 +51,15 @@ push to `main`. To enable:
 
 ## Comments (Giscus)
 
-Stubbed in `src/components/Giscus.astro`. To enable:
+Giscus is configured in `src/components/Giscus.astro`.
 
-1. Enable Discussions on the repo.
-2. Install <https://github.com/apps/giscus>.
-3. Visit <https://giscus.app>, configure for this repo, copy the `data-repo-id`
-   and `data-category-id`.
-4. Edit `src/components/Giscus.astro`, paste the IDs, flip `disabled = false`.
+To maintain it:
+
+1. Keep GitHub Discussions enabled on the repo.
+2. Keep the giscus app installed: <https://github.com/apps/giscus>.
+3. Update `data-repo`, `data-repo-id`, or `data-category-id` only if the
+   repository or discussion category changes.
+4. Keep `data-theme="dark"` so comments match the dark-only site theme.
 
 ## Planning docs (not published)
 

--- a/docs/superpowers/plans/2026-05-31-owasp-llm-top-10-presentation-package.md
+++ b/docs/superpowers/plans/2026-05-31-owasp-llm-top-10-presentation-package.md
@@ -1,0 +1,1593 @@
+# OWASP LLM Top 10 Presentation Package Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a repo-native presentation package for the accepted June 23, 2026 OWASP LLM Top 10 lab talk, with a polished Google Slides delivery path and public post-talk viewing path.
+
+**Architecture:** Keep the editable talk materials under `talks/summit-owasp-llm-top-10/` and add a static Astro public talk page for browser viewing/export without new dependencies. Use the existing dark sci-fi operations site theme, mirror the same content across Markdown source and the public page, and keep the live demo optional through a detailed runbook and fallback path.
+
+**Tech Stack:** Astro 6 static site, repo-native Markdown, route-local Astro CSS, existing lab Python/Docker commands, GitHub issue/PR workflow, Google Slides as manual delivery copy.
+
+---
+
+## File Structure
+
+- Modify `talks/summit-owasp-llm-top-10/outline.md`: keep the existing outline as the planning index and update it to point to the final package files.
+- Create `talks/summit-owasp-llm-top-10/README.md`: public package entry point with deadlines, viewing paths, and artifact list.
+- Create `talks/summit-owasp-llm-top-10/abstract.md`: final title, abstract, audience, takeaways, and short submission blurb.
+- Create `talks/summit-owasp-llm-top-10/slides.md`: repo-native slide source for review and Google Slides mirroring.
+- Create `talks/summit-owasp-llm-top-10/speaker-notes.md`: slide-by-slide notes and timing.
+- Create `talks/summit-owasp-llm-top-10/demo-runbook.md`: live demo setup, commands, expected output, timing, fallback, and recovery.
+- Create `talks/summit-owasp-llm-top-10/assets/README.md`: asset policy and future asset inventory.
+- Create `talks/summit-owasp-llm-top-10/exports/README.md`: export policy for PDF/Google Slides/public artifacts.
+- Create `src/pages/talks/summit-owasp-llm-top-10.astro`: static public talk page with slide-like sections and print-friendly styling.
+- Modify `README.md`: add a short link to the repo-native presentation package after the talk package exists.
+
+No new npm dependencies are planned. Do not add a slide framework unless a later issue explicitly approves it.
+
+---
+
+### Task 1: Talk Package Index And Abstract
+
+**Files:**
+- Create: `talks/summit-owasp-llm-top-10/README.md`
+- Create: `talks/summit-owasp-llm-top-10/abstract.md`
+- Modify: `talks/summit-owasp-llm-top-10/outline.md`
+
+- [ ] **Step 1: Create the talk package README**
+
+Create `talks/summit-owasp-llm-top-10/README.md` with:
+
+```markdown
+# Breaking Agents to Build Better Ones
+
+A 30-minute technical talk for engineers on building a local AI red-team lab
+around the OWASP Top 10 for LLM Applications.
+
+## Dates
+
+- Final polished deck and demo target: June 20, 2026
+- Talk date: June 23, 2026
+- Prepared talk target: 25 minutes
+- Q&A, padding, or demo recovery: 5 minutes
+
+## Core Thesis
+
+Engineers learn AI security faster when the risks are executable. The OWASP Top
+10 is the threat map; the lab is the method: build a vulnerable target, attack
+it, measure the baseline, add a defense, rerun the harness, and compare the
+result.
+
+## Artifacts
+
+- `abstract.md` - final title, abstract, audience, and takeaways.
+- `slides.md` - repo-native slide source for review and Google Slides mirroring.
+- `speaker-notes.md` - slide-by-slide narration notes and timing.
+- `demo-runbook.md` - live demo setup, commands, fallback, and recovery path.
+- `assets/` - local diagrams or images used by the deck.
+- `exports/` - exported PDF or HTML artifacts when generated.
+
+## Viewing Paths
+
+- Live delivery: Google Slides copy created from `slides.md`.
+- Repo-native source: `slides.md`.
+- Public web version: `/talks/summit-owasp-llm-top-10/` once deployed.
+
+## Scope
+
+The talk prioritizes the lab method over exhaustive OWASP coverage. The Top 10
+appears as a fast threat map, then the deck focuses on `LLM01:2025` prompt
+injection as the concrete demo path.
+
+## Safety Boundary
+
+All examples use local, owned, synthetic targets. The talk does not use real
+credentials, real company data, real customer data, or third-party targets.
+```
+
+- [ ] **Step 2: Create the final abstract**
+
+Create `talks/summit-owasp-llm-top-10/abstract.md` with:
+
+```markdown
+# Talk Abstract
+
+## Title
+
+Breaking Agents to Build Better Ones
+
+## Subtitle
+
+A hands-on lab for the OWASP Top 10 for LLM Applications
+
+## Short Abstract
+
+AI security gets easier to reason about when the risks are executable. This talk
+walks through a local AI red-team lab built around the OWASP Top 10 for LLM
+Applications. We use the Top 10 as a threat map, then focus on the lab method:
+build a small vulnerable agent, attack it, measure the baseline, add a defense,
+and measure again.
+
+The concrete example is `LLM01:2025` prompt injection against a vulnerable RAG
+assistant. We will look at an attacker-controlled retrieved document, an attack
+harness, a baseline attack-success result, a spotlighting-style defense toggle,
+and the measured delta. The goal is not to claim that one defense solves prompt
+injection. The goal is to show how engineers can turn vague AI security concerns
+into repeatable experiments.
+
+## Audience
+
+- Product engineers building LLM features or agent workflows.
+- Platform engineers supporting AI developer tooling.
+- AppSec engineers reviewing AI system designs.
+- Engineering leaders deciding where agent guardrails matter.
+
+## Takeaways
+
+- Agents expand the attack surface beyond the chat input box.
+- Retrieved documents, logs, dependency files, tool output, and memory are all
+  untrusted input.
+- A useful AI security lab needs a target, fixtures, payloads, an attack harness,
+  defenses, measured results, and a writeup.
+- Defense claims should be compared against baseline attack success rate.
+- The OWASP Top 10 becomes more useful when each category maps to a local,
+  reproducible experiment.
+
+## Delivery Notes
+
+- Prepared talk target: 25 minutes.
+- Reserve 5 minutes for questions, demo recovery, or skipped-slide padding.
+- Live demo is optional; the talk must work with a recorded or screenshot
+  fallback.
+```
+
+- [ ] **Step 3: Update the existing outline as an index**
+
+At the top of `talks/summit-owasp-llm-top-10/outline.md`, after the title, add:
+
+```markdown
+> Package status: this outline is the planning index. The delivery artifacts are
+> `abstract.md`, `slides.md`, `speaker-notes.md`, and `demo-runbook.md`. The
+> public web version is implemented at
+> `src/pages/talks/summit-owasp-llm-top-10.astro`.
+```
+
+- [ ] **Step 4: Validate markdown and commit Task 1**
+
+Run:
+
+```bash
+git diff --check
+rg -n "TBD|TODO|FIXME|\\?\\?" talks/summit-owasp-llm-top-10/README.md talks/summit-owasp-llm-top-10/abstract.md talks/summit-owasp-llm-top-10/outline.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- `rg` exits 1 with no placeholder matches.
+
+Commit:
+
+```bash
+git add talks/summit-owasp-llm-top-10/README.md talks/summit-owasp-llm-top-10/abstract.md talks/summit-owasp-llm-top-10/outline.md
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Add presentation package overview"
+```
+
+---
+
+### Task 2: Repo-Native Slide Source
+
+**Files:**
+- Create: `talks/summit-owasp-llm-top-10/slides.md`
+
+- [ ] **Step 1: Create `slides.md` front matter and usage note**
+
+Create `talks/summit-owasp-llm-top-10/slides.md` with this complete content:
+
+```markdown
+# Breaking Agents to Build Better Ones
+
+> Repo-native slide source for the June 23, 2026 talk. Mirror this content into
+> Google Slides for live delivery. Keep the public web version in
+> `src/pages/talks/summit-owasp-llm-top-10.astro` aligned with this file.
+
+---
+
+## 1. Title
+
+**Breaking Agents to Build Better Ones**
+
+A hands-on lab for the OWASP Top 10 for LLM Applications.
+
+Speaker: Shawn Campbell
+
+---
+
+## 2. The Claim
+
+AI security gets easier when the risks are executable.
+
+The OWASP Top 10 is the threat map. The lab is how we turn that map into
+engineering practice.
+
+---
+
+## 3. Why Agents Change The Surface
+
+Agents are not just chat boxes.
+
+They combine:
+
+- instructions,
+- retrieved text,
+- tools,
+- memory,
+- automation,
+- and output consumed by other systems.
+
+---
+
+## 4. The Uncomfortable Idea
+
+Every string the agent reads can become an attack path.
+
+Examples:
+
+- support notes,
+- logs,
+- dependency READMEs,
+- Jira comments,
+- retrieved policy docs,
+- MCP tool output,
+- saved memory.
+
+---
+
+## 5. OWASP Top 10 As Threat Map
+
+Use the list to ask better engineering questions:
+
+| Item | Engineering question |
+|---|---|
+| LLM01 Prompt Injection | What untrusted text reaches the model? |
+| LLM02 Sensitive Information Disclosure | What data is in context that should not be? |
+| LLM03 Supply Chain | What code or content does the agent trust? |
+| LLM05 Improper Output Handling | Who consumes model output next? |
+| LLM06 Excessive Agency | What can tools do if text steers them? |
+
+---
+
+## 6. The Rest Of The Map
+
+| Item | Engineering question |
+|---|---|
+| LLM04 Data and Model Poisoning | Can poisoned data persist or bias retrieval? |
+| LLM07 System Prompt Leakage | Are hidden instructions treated like secrets? |
+| LLM08 Vector and Embedding Weaknesses | Can retrieval be steered by neighbors? |
+| LLM09 Misinformation | Can the agent prove what it says? |
+| LLM10 Unbounded Consumption | Can prompts amplify cost, loops, or tool calls? |
+
+---
+
+## 7. Why Build A Lab?
+
+Because "prompt injection is bad" is not an engineering result.
+
+A lab lets you:
+
+- reproduce the failure,
+- define attack success,
+- measure a baseline,
+- add one defense,
+- rerun the same harness,
+- compare the delta.
+
+---
+
+## 8. The Lab Loop
+
+```text
+target -> payloads -> attack harness -> result
+   ^                                      |
+   |                                      v
+defense toggle <- compare delta <- rerun harness
+```
+
+The important part is repeatability.
+
+---
+
+## 9. Key Lab Components
+
+- Vulnerable local target
+- Synthetic fixtures
+- Payload library
+- Attack runner
+- Result file
+- Defense toggle
+- Writeup
+- Safety boundary
+
+No real credentials. No real customer data. No third-party targets.
+
+---
+
+## 10. Concrete Demo: LLM01
+
+Target: vulnerable RAG assistant.
+
+Attack: indirect prompt injection through a retrieved document.
+
+Attacker goal: make the assistant follow hostile document instructions instead
+of the user request and system intent.
+
+---
+
+## 11. The Attack Path
+
+```text
+user question
+  -> retriever
+  -> trusted docs + attacker-controlled support note
+  -> model context
+  -> answer or unsafe action
+```
+
+The user did not type the attack. The model still read it.
+
+---
+
+## 12. What Counts As Success?
+
+An attack succeeds when the assistant follows the injected instruction instead
+of the intended task boundary.
+
+A useful metric is attack success rate:
+
+```text
+successful attacks / total attempts
+```
+
+This is not universal truth. It is a controlled lab signal.
+
+---
+
+## 13. Baseline Run
+
+Defense off:
+
+- Run the same payload set.
+- Record every response.
+- Score whether the attack objective succeeded.
+- Save structured results.
+
+The baseline is the thing every defense has to beat.
+
+---
+
+## 14. Defense Toggle
+
+Example defense: spotlighting or untrusted-content labeling.
+
+The core idea:
+
+- preserve the content,
+- mark its trust boundary,
+- tell the model how to treat quoted or retrieved text,
+- measure whether behavior changes.
+
+---
+
+## 15. Defense Run
+
+Defense on:
+
+- same target,
+- same payloads,
+- same scoring,
+- same result format.
+
+Only the defense changes.
+
+That is what makes the comparison useful.
+
+---
+
+## 16. What This Proves
+
+It can show:
+
+- the attack is reproducible,
+- the defense changed behavior in this lab,
+- the result is measurable,
+- the failure can become a regression test.
+
+It does not prove:
+
+- prompt injection is solved,
+- the defense generalizes everywhere,
+- all future payloads fail.
+
+---
+
+## 17. Extending Across The Top 10
+
+The same pattern works for:
+
+- supply-chain prompt injection,
+- excessive agency,
+- improper output handling,
+- sensitive information disclosure,
+- system prompt leakage,
+- vector retrieval weaknesses,
+- misinformation,
+- unbounded consumption.
+
+---
+
+## 18. Two High-Value Next Labs
+
+LLM03 Supply Chain:
+
+- dependency files become prompt-injection seeds,
+- coding agents read them during review,
+- package content crosses into model context.
+
+LLM06 Excessive Agency:
+
+- tools turn text influence into real actions,
+- least privilege matters more than prompt wording.
+
+---
+
+## 19. Design Review Checklist
+
+Ask:
+
+- What untrusted text enters context?
+- What tools can the agent call?
+- What secrets or sensitive data can it see?
+- What consumes model output next?
+- What is logged, budgeted, and cancellable?
+- Can we reproduce the attack locally?
+- Can we measure the defense against a baseline?
+
+---
+
+## 20. Live Demo Or Recorded Walkthrough
+
+If time permits:
+
+1. Start the local lab.
+2. Show the poisoned fixture.
+3. Run the attack harness with defense off.
+4. Run it again with defense on.
+5. Compare the result files.
+
+If time is tight, use the captured output and keep moving.
+
+---
+
+## 21. Roadmap
+
+The lab grows one measured slice at a time:
+
+- first slice for each OWASP category,
+- richer payload variants,
+- stronger eval metadata,
+- clearer writeups,
+- public lesson workflow after the lab, blog, and presentation are complete.
+
+---
+
+## 22. Close
+
+Build small broken agents.
+
+Attack them honestly.
+
+Measure what changed.
+
+Carry the evidence back into real engineering decisions.
+
+---
+
+## Appendix A. Safety Boundary
+
+- Local targets only.
+- Synthetic data only.
+- No real credentials.
+- No customer data.
+- No third-party probing.
+- Vulnerable behavior stays inside owned lab services.
+
+---
+
+## Appendix B. Demo Commands
+
+```bash
+cd lab
+docker compose up --build
+python attacker/custom/run_v0_rag_attacks.py
+python attacker/custom/run_v0_rag_attacks.py --defense spotlighting
+```
+
+Use the exact commands from `demo-runbook.md` if they diverge from this short
+reference.
+
+---
+
+## Appendix C. References
+
+- OWASP Top 10 for LLM Applications
+- OWASP GenAI Security Project
+- Repo lab roadmap: `lab/owasp-llm-top-10/roadmap.md`
+- LLM01 writeup: `lab/writeups/001-injection-via-rag.md`
+```
+
+- [ ] **Step 2: Validate slide source and commit Task 2**
+
+Run:
+
+```bash
+git diff --check
+rg -n "TBD|TODO|FIXME|\\?\\?" talks/summit-owasp-llm-top-10/slides.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- `rg` exits 1 with no placeholder matches.
+
+Commit:
+
+```bash
+git add talks/summit-owasp-llm-top-10/slides.md
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Draft OWASP lab talk slides"
+```
+
+---
+
+### Task 3: Speaker Notes
+
+**Files:**
+- Create: `talks/summit-owasp-llm-top-10/speaker-notes.md`
+
+- [ ] **Step 1: Create slide-by-slide speaker notes**
+
+Create `talks/summit-owasp-llm-top-10/speaker-notes.md` with:
+
+```markdown
+# Speaker Notes
+
+Target: 25 minutes prepared content, 5 minutes for questions, demo recovery, or
+skipped-slide padding.
+
+## Timing Plan
+
+| Segment | Slides | Target |
+|---|---:|---:|
+| Frame the problem | 1-4 | 4 min |
+| Threat map | 5-6 | 4 min |
+| Lab method | 7-9 | 6 min |
+| LLM01 walkthrough | 10-16 | 9 min |
+| Extension and close | 17-22 | 2 min |
+| Buffer/Q&A | Appendix or discussion | 5 min |
+
+## Slide Notes
+
+### 1. Title
+
+Open with the core promise: this is not a theoretical AI security survey. It is
+about making risks executable so engineers can test them.
+
+### 2. The Claim
+
+Emphasize that the OWASP Top 10 is useful, but a taxonomy does not prove a
+system is safe. The lab turns the taxonomy into a repeatable engineering loop.
+
+### 3. Why Agents Change The Surface
+
+Make the distinction between a chatbot and an agent. The risk changes when text
+can influence retrieval, tools, memory, scheduled work, or downstream systems.
+
+### 4. The Uncomfortable Idea
+
+Use concrete examples. The attacker may never touch the chat input. They may
+control a log line, a support note, a dependency README, or a document the agent
+retrieves.
+
+### 5. OWASP Top 10 As Threat Map
+
+Move quickly. Do not explain every OWASP category in depth. Reframe each item as
+an engineering question.
+
+### 6. The Rest Of The Map
+
+Use this slide to show breadth, then pivot away from list coverage. Say that the
+audience can read the list later; the talk is about making it executable.
+
+### 7. Why Build A Lab?
+
+Contrast vague claims with measured claims. A defense is more credible when it
+beats the same harness that broke the baseline.
+
+### 8. The Lab Loop
+
+Walk through the loop slowly: target, payloads, harness, result, defense, rerun,
+compare. Stress that changing one variable at a time is what makes the result
+useful.
+
+### 9. Key Lab Components
+
+Tie each component to reproducibility. The writeup matters because future
+engineers need to rerun the experiment, not trust a screenshot.
+
+### 10. Concrete Demo: LLM01
+
+Set context for the demo. The vulnerable RAG assistant retrieves useful
+documents, but one retrieved document can carry hostile instructions.
+
+### 11. The Attack Path
+
+Point out that the user question can be benign. The attack enters through the
+retrieval path.
+
+### 12. What Counts As Success?
+
+Define success before showing results. This prevents the demo from becoming a
+vibe check.
+
+### 13. Baseline Run
+
+If running live, show the command and result. If using fallback, show captured
+output and explain the fields in the result file.
+
+### 14. Defense Toggle
+
+Explain spotlighting as trust-boundary labeling, not magic. The model still sees
+the content; the prompt structure changes how the model should treat it.
+
+### 15. Defense Run
+
+Stress same payloads, same scoring, same result format. Only the defense changes.
+
+### 16. What This Proves
+
+Be careful and credible. The result is evidence, not a universal guarantee.
+This slide is important for the CTO-level audience.
+
+### 17. Extending Across The Top 10
+
+Show that the lab method scales beyond prompt injection. Keep this fast.
+
+### 18. Two High-Value Next Labs
+
+Name supply chain and excessive agency because they connect directly to AI
+coding-agent risk and real engineering decisions.
+
+### 19. Design Review Checklist
+
+This is the practical takeaway. Give the audience questions they can use at work
+the next day.
+
+### 20. Live Demo Or Recorded Walkthrough
+
+Use this slide only if time permits. If the clock is tight, say the repo contains
+the runbook and move to the close.
+
+### 21. Roadmap
+
+Mention that the first lab slices exist and the plan is to deepen payloads,
+metadata, writeups, and later the interactive lesson workflow.
+
+### 22. Close
+
+End with the method: build small broken agents, attack them honestly, measure
+what changed, and carry the evidence back into real engineering decisions.
+
+## Rehearsal Notes
+
+- If slide 6 ends after minute 8, skip the live demo and use fallback output.
+- If slide 16 ends after minute 22, skip slide 20.
+- Keep appendix slides for questions.
+- Do not apologize for skipping the live demo; frame it as preserving time for
+  the engineering method.
+```
+
+- [ ] **Step 2: Validate notes and commit Task 3**
+
+Run:
+
+```bash
+git diff --check
+rg -n "TBD|TODO|FIXME|\\?\\?" talks/summit-owasp-llm-top-10/speaker-notes.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- `rg` exits 1 with no placeholder matches.
+
+Commit:
+
+```bash
+git add talks/summit-owasp-llm-top-10/speaker-notes.md
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Add OWASP lab talk speaker notes"
+```
+
+---
+
+### Task 4: Demo Runbook
+
+**Files:**
+- Create: `talks/summit-owasp-llm-top-10/demo-runbook.md`
+
+- [ ] **Step 1: Inspect current lab commands**
+
+Run:
+
+```bash
+sed -n '1,220p' lab/README.md
+sed -n '1,220p' lab/vulnerable-agents/injection-via-rag/README.md
+sed -n '1,220p' lab/attacker/README.md
+```
+
+Expected:
+
+- Identify the current `LLM01` startup and attack commands.
+- If commands differ from the short reference in `slides.md`, use the commands
+  from the lab documentation in the runbook.
+
+- [ ] **Step 2: Create the demo runbook**
+
+Create `talks/summit-owasp-llm-top-10/demo-runbook.md` with:
+
+```markdown
+# Demo Runbook
+
+Primary demo: `LLM01:2025` prompt injection against the vulnerable RAG lab.
+
+The demo is optional. The talk must work with captured output if live Docker,
+API access, network, or time fails.
+
+## Safety Boundary
+
+- Local lab targets only.
+- Synthetic fixtures only.
+- No real credentials.
+- No company data.
+- No customer data.
+- No third-party targets.
+
+## Timing
+
+Target live demo length: 5 to 7 minutes.
+
+Abort live demo and use fallback if:
+
+- the lab is not ready by minute 15 of the talk,
+- Docker startup takes longer than 90 seconds,
+- the first attack command fails for an environmental reason,
+- projector or network issues make terminal output unreadable.
+
+## Prerequisites
+
+- Docker is running.
+- Repository is cloned locally.
+- Dependencies are installed according to `lab/README.md`.
+- Terminal font is large enough for the room.
+- Browser is open to the local vulnerable app if using the HTTP view.
+- Captured fallback output is available in `talks/summit-owasp-llm-top-10/exports/`.
+
+## Setup Before The Talk
+
+From the repo root:
+
+```bash
+cd lab
+docker compose up --build
+```
+
+In a second terminal, confirm the app health check or local endpoint documented
+by `lab/README.md`.
+
+## Live Demo Path
+
+1. Show the vulnerable target.
+
+   Explain that the assistant is supposed to answer from retrieved support
+   material.
+
+2. Show the poisoned fixture or attacker-controlled support note.
+
+   Point out that the user does not type the attack directly.
+
+3. Run the baseline harness with the defense off.
+
+   ```bash
+   cd lab
+   python attacker/custom/run_v0_rag_attacks.py
+   ```
+
+4. Show the result file.
+
+   ```bash
+   cat evals/results/v0-rag-latest.json
+   ```
+
+   Explain the attack-success fields and avoid overclaiming.
+
+5. Run the defense-on version.
+
+   ```bash
+   cd lab
+   python attacker/custom/run_v0_rag_attacks.py --defense spotlighting
+   ```
+
+6. Compare the result file again.
+
+   ```bash
+   cat evals/results/v0-rag-latest.json
+   ```
+
+   Explain what changed and what did not.
+
+## Fallback Path
+
+If the live demo fails or time is tight:
+
+1. Show the slide explaining the attack path.
+2. Show captured baseline output from `exports/`.
+3. Show captured defense-on output from `exports/`.
+4. Explain the same result fields.
+5. Move to the "What this proves" slide.
+
+## Recovery Lines
+
+Use these if the live demo fails:
+
+- "The useful part of this demo is not the terminal theatrics; it is the shape of
+  the experiment."
+- "The captured output shows the same harness and result format, so we can keep
+  the comparison honest."
+- "This is why the runbook is part of the artifact. A security demo should be
+  reproducible after the room clears."
+
+## Post-Talk Follow-Up
+
+- Link the public talk page from the README.
+- Link the lab roadmap and `LLM01` writeup.
+- Add the Google Slides link once the delivery copy is created.
+```
+
+- [ ] **Step 3: Run a documented dry run or record blocker**
+
+Run the commands from the runbook if the local environment supports them:
+
+```bash
+cd lab
+python attacker/custom/run_v0_rag_attacks.py
+```
+
+Expected:
+
+- The command exits 0 and writes `lab/evals/results/v0-rag-latest.json`, or
+- The runbook gets a short "Current Dry Run Status" section documenting the
+  blocker and fallback path.
+
+If the command requires Docker or dependencies that are unavailable, add this
+section to `demo-runbook.md`:
+
+```markdown
+## Current Dry Run Status
+
+The runbook has not yet been fully dry-run in this branch. The fallback path is
+to use captured output in `exports/` until the live lab is verified on the
+presentation machine.
+```
+
+- [ ] **Step 4: Validate and commit Task 4**
+
+Run:
+
+```bash
+git diff --check
+rg -n "TBD|TODO|FIXME|\\?\\?" talks/summit-owasp-llm-top-10/demo-runbook.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- `rg` exits 1 with no placeholder matches.
+
+Commit:
+
+```bash
+git add talks/summit-owasp-llm-top-10/demo-runbook.md
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Add OWASP lab demo runbook"
+```
+
+---
+
+### Task 5: Public Talk Page
+
+**Files:**
+- Create: `src/pages/talks/summit-owasp-llm-top-10.astro`
+
+- [ ] **Step 1: Create the public Astro talk page**
+
+Create `src/pages/talks/summit-owasp-llm-top-10.astro` with:
+
+```astro
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const slides = [
+  {
+    kicker: 'Field Brief',
+    title: 'Breaking Agents to Build Better Ones',
+    body: [
+      'A hands-on lab for the OWASP Top 10 for LLM Applications.',
+      'Shawn Campbell / June 23, 2026',
+    ],
+  },
+  {
+    kicker: 'Claim',
+    title: 'AI security gets easier when the risks are executable.',
+    body: [
+      'The OWASP Top 10 is the threat map. The lab is how we turn that map into engineering practice.',
+    ],
+  },
+  {
+    kicker: 'Attack Surface',
+    title: 'Agents are not just chat boxes.',
+    bullets: ['Instructions', 'Retrieved text', 'Tools', 'Memory', 'Automation', 'Downstream output'],
+  },
+  {
+    kicker: 'Untrusted Terrain',
+    title: 'Every string the agent reads can become an attack path.',
+    bullets: [
+      'Support notes',
+      'Logs',
+      'Dependency READMEs',
+      'Jira comments',
+      'Retrieved policy docs',
+      'MCP tool output',
+      'Saved memory',
+    ],
+  },
+  {
+    kicker: 'Threat Map',
+    title: 'OWASP Top 10 as engineering questions',
+    table: [
+      ['LLM01 Prompt Injection', 'What untrusted text reaches the model?'],
+      ['LLM02 Sensitive Information Disclosure', 'What data is in context that should not be?'],
+      ['LLM03 Supply Chain', 'What code or content does the agent trust?'],
+      ['LLM05 Improper Output Handling', 'Who consumes model output next?'],
+      ['LLM06 Excessive Agency', 'What can tools do if text steers them?'],
+    ],
+  },
+  {
+    kicker: 'Threat Map',
+    title: 'The rest of the map',
+    table: [
+      ['LLM04 Data and Model Poisoning', 'Can poisoned data persist or bias retrieval?'],
+      ['LLM07 System Prompt Leakage', 'Are hidden instructions treated like secrets?'],
+      ['LLM08 Vector and Embedding Weaknesses', 'Can retrieval be steered by neighbors?'],
+      ['LLM09 Misinformation', 'Can the agent prove what it says?'],
+      ['LLM10 Unbounded Consumption', 'Can prompts amplify cost, loops, or tool calls?'],
+    ],
+  },
+  {
+    kicker: 'Lab Rationale',
+    title: 'A lab turns vague risk into a measured result.',
+    bullets: [
+      'Reproduce the failure',
+      'Define attack success',
+      'Measure a baseline',
+      'Add one defense',
+      'Rerun the same harness',
+      'Compare the delta',
+    ],
+  },
+  {
+    kicker: 'Method',
+    title: 'The lab loop',
+    code: 'target -> payloads -> attack harness -> result\\n   ^                                      |\\n   |                                      v\\ndefense toggle <- compare delta <- rerun harness',
+  },
+  {
+    kicker: 'Components',
+    title: 'What a useful AI security lab needs',
+    bullets: [
+      'Vulnerable local target',
+      'Synthetic fixtures',
+      'Payload library',
+      'Attack runner',
+      'Result file',
+      'Defense toggle',
+      'Writeup',
+      'Safety boundary',
+    ],
+  },
+  {
+    kicker: 'Demo',
+    title: 'Concrete demo: LLM01 prompt injection',
+    body: [
+      'Target: vulnerable RAG assistant.',
+      'Attack: indirect prompt injection through a retrieved document.',
+      'Goal: make the assistant follow hostile document instructions instead of the intended task boundary.',
+    ],
+  },
+  {
+    kicker: 'Attack Path',
+    title: 'The user does not have to type the attack.',
+    code: 'user question\\n  -> retriever\\n  -> trusted docs + attacker-controlled support note\\n  -> model context\\n  -> answer or unsafe action',
+  },
+  {
+    kicker: 'Metric',
+    title: 'Define success before showing results.',
+    body: [
+      'An attack succeeds when the assistant follows the injected instruction instead of the intended task boundary.',
+    ],
+    code: 'attack success rate = successful attacks / total attempts',
+  },
+  {
+    kicker: 'Baseline',
+    title: 'Defense off gives every future claim something to beat.',
+    bullets: ['Same payload set', 'Every response recorded', 'Attack objective scored', 'Structured result saved'],
+  },
+  {
+    kicker: 'Defense',
+    title: 'Spotlighting marks the trust boundary.',
+    bullets: [
+      'Preserve retrieved content',
+      'Label untrusted text',
+      'Tell the model how to treat quoted material',
+      'Measure whether behavior changes',
+    ],
+  },
+  {
+    kicker: 'Comparison',
+    title: 'Defense on changes one variable.',
+    bullets: ['Same target', 'Same payloads', 'Same scoring', 'Same result format', 'Only the defense changes'],
+  },
+  {
+    kicker: 'Evidence',
+    title: 'What this proves and does not prove',
+    table: [
+      ['Can show', 'Attack is reproducible; behavior changed in this lab; the failure can become a regression test.'],
+      ['Does not show', 'Prompt injection is solved; the defense generalizes everywhere; all future payloads fail.'],
+    ],
+  },
+  {
+    kicker: 'Scale Out',
+    title: 'The same pattern extends across the Top 10.',
+    bullets: [
+      'Supply-chain prompt injection',
+      'Excessive agency',
+      'Improper output handling',
+      'Sensitive information disclosure',
+      'System prompt leakage',
+      'Vector retrieval weaknesses',
+      'Misinformation',
+      'Unbounded consumption',
+    ],
+  },
+  {
+    kicker: 'Next Labs',
+    title: 'Two high-value next labs',
+    table: [
+      ['LLM03 Supply Chain', 'Dependency files become prompt-injection seeds for coding agents.'],
+      ['LLM06 Excessive Agency', 'Tools turn text influence into real actions.'],
+    ],
+  },
+  {
+    kicker: 'Checklist',
+    title: 'Design-review questions',
+    bullets: [
+      'What untrusted text enters context?',
+      'What tools can the agent call?',
+      'What secrets or sensitive data can it see?',
+      'What consumes model output next?',
+      'What is logged, budgeted, and cancellable?',
+      'Can we reproduce the attack locally?',
+      'Can we measure the defense against a baseline?',
+    ],
+  },
+  {
+    kicker: 'Demo Window',
+    title: 'Live demo or recorded walkthrough',
+    bullets: [
+      'Start the local lab',
+      'Show the poisoned fixture',
+      'Run defense off',
+      'Run defense on',
+      'Compare the result files',
+    ],
+  },
+  {
+    kicker: 'Roadmap',
+    title: 'The lab grows one measured slice at a time.',
+    bullets: [
+      'First slice for each OWASP category',
+      'Richer payload variants',
+      'Stronger eval metadata',
+      'Clearer writeups',
+      'Public lesson workflow after lab, blog, and presentation work',
+    ],
+  },
+  {
+    kicker: 'Close',
+    title: 'Build small broken agents. Attack them honestly. Measure what changed.',
+    body: ['Then carry the evidence back into real engineering decisions.'],
+  },
+];
+---
+
+<BaseLayout
+  title="Breaking Agents to Build Better Ones"
+  description="A repo-native presentation for building AI red-team labs around the OWASP Top 10 for LLM Applications."
+>
+  <section class="talk-hero panel">
+    <p class="kicker">Presentation Package</p>
+    <h1>Breaking Agents to Build Better Ones</h1>
+    <p>
+      A hands-on lab for the OWASP Top 10 for LLM Applications. This public
+      version mirrors the repo-native slide source and is designed for post-talk
+      viewing without Google Slides.
+    </p>
+    <nav aria-label="Talk resources">
+      <a href="/ai_sec_research/talks/summit-owasp-llm-top-10/">Public talk page</a>
+      <a href="https://github.com/jaegerpicker/ai_sec_research/tree/main/talks/summit-owasp-llm-top-10">Repo materials</a>
+    </nav>
+  </section>
+
+  <div class="slide-stack" aria-label="Slide deck">
+    {slides.map((slide, index) => (
+      <section class="slide panel" aria-labelledby={`slide-${index + 1}`}>
+        <p class="kicker">{String(index + 1).padStart(2, '0')} / {slide.kicker}</p>
+        <h2 id={`slide-${index + 1}`}>{slide.title}</h2>
+
+        {slide.body?.map((paragraph) => <p>{paragraph}</p>)}
+
+        {slide.bullets && (
+          <ul>
+            {slide.bullets.map((bullet) => <li>{bullet}</li>)}
+          </ul>
+        )}
+
+        {slide.table && (
+          <table>
+            <tbody>
+              {slide.table.map((row) => (
+                <tr>
+                  <th scope="row">{row[0]}</th>
+                  <td>{row[1]}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {slide.code && <pre><code>{slide.code}</code></pre>}
+      </section>
+    ))}
+  </div>
+</BaseLayout>
+
+<style>
+  .talk-hero {
+    margin-bottom: 1rem;
+    padding: clamp(1.25rem, 3vw, 2rem);
+  }
+
+  .talk-hero h1 {
+    margin: 0 0 0.75rem;
+    max-width: 13ch;
+    font-size: clamp(2.5rem, 8vw, 5.4rem);
+    line-height: 0.95;
+  }
+
+  .talk-hero p:not(.kicker) {
+    max-width: 52rem;
+    color: var(--fg-muted);
+    font-size: 1.08rem;
+  }
+
+  .talk-hero nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+
+  .talk-hero nav a {
+    border: 1px solid var(--border);
+    color: var(--link);
+    font-family: var(--font-mono);
+    padding: 0.45rem 0.7rem;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .talk-hero nav a:hover,
+  .talk-hero nav a:focus-visible {
+    border-color: var(--border-strong);
+    color: var(--warning-strong);
+  }
+
+  .slide-stack {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .slide {
+    min-height: min(74vh, 44rem);
+    padding: clamp(1.25rem, 4vw, 2.4rem);
+  }
+
+  .slide h2 {
+    max-width: 18ch;
+    margin: 0 0 1rem;
+    font-size: clamp(2rem, 5vw, 4.2rem);
+    line-height: 1;
+  }
+
+  .slide p,
+  .slide li,
+  .slide td,
+  .slide th {
+    font-size: clamp(1rem, 1.6vw, 1.28rem);
+  }
+
+  .slide p {
+    max-width: 58rem;
+    color: var(--fg-muted);
+  }
+
+  .slide ul {
+    display: grid;
+    gap: 0.4rem;
+    max-width: 58rem;
+    padding-left: 1.2rem;
+  }
+
+  .slide li::marker {
+    color: var(--warning);
+  }
+
+  .slide table {
+    max-width: 62rem;
+  }
+
+  .slide th {
+    width: 34%;
+    color: var(--accent-strong);
+    font-family: var(--font-mono);
+    vertical-align: top;
+  }
+
+  .slide pre {
+    max-width: 62rem;
+    white-space: pre-wrap;
+  }
+
+  @media print {
+    header,
+    footer,
+    .talk-hero {
+      display: none;
+    }
+
+    main {
+      width: 100%;
+      padding: 0;
+    }
+
+    .slide {
+      min-height: 100vh;
+      break-after: page;
+      box-shadow: none;
+    }
+  }
+</style>
+```
+
+- [ ] **Step 2: Fix the base URL link in the hero**
+
+The generated page must work under GitHub Pages base paths. Replace the two
+hard-coded `href` values in the hero nav with a `base` constant.
+
+Add this in the frontmatter after the import:
+
+```astro
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+```
+
+Then replace the first hero nav link with:
+
+```astro
+<a href={`${base}/talks/summit-owasp-llm-top-10`}>Public talk page</a>
+```
+
+Keep the GitHub repository link as an absolute external URL.
+
+- [ ] **Step 3: Build and inspect generated route**
+
+Run:
+
+```bash
+ASTRO_TELEMETRY_DISABLED=1 npm run build
+rg -n "Breaking Agents to Build Better Ones|Design-review questions|giscus|href=\"/talks" dist/talks/summit-owasp-llm-top-10/index.html
+```
+
+Expected:
+
+- Build exits 0.
+- The `rg` output includes the talk title and design-review slide.
+- The `rg` output does not include `href="/talks`; internal links should include the configured base path when built for GitHub Pages.
+- `giscus` may be absent from the talk page; comments are only expected on blog posts.
+
+- [ ] **Step 4: Commit Task 5**
+
+Run:
+
+```bash
+git add src/pages/talks/summit-owasp-llm-top-10.astro
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Add public OWASP lab talk page"
+```
+
+---
+
+### Task 6: Asset And Export Policy
+
+**Files:**
+- Create: `talks/summit-owasp-llm-top-10/assets/README.md`
+- Create: `talks/summit-owasp-llm-top-10/exports/README.md`
+
+- [ ] **Step 1: Create the asset policy**
+
+Create `talks/summit-owasp-llm-top-10/assets/README.md` with:
+
+```markdown
+# Talk Assets
+
+Store local images, diagrams, screenshots, and terminal captures for the OWASP
+LLM Top 10 lab presentation here.
+
+## Rules
+
+- Use original diagrams or screenshots from owned local lab targets.
+- Do not commit real credentials, customer data, company-private screenshots, or
+  third-party target data.
+- Do not use copyrighted franchise art, logos, characters, or direct visual
+  reproductions.
+- Prefer SVG, PNG, or WebP.
+- Keep filenames descriptive, such as `llm01-attack-path.png` or
+  `lab-architecture.svg`.
+
+## Current Assets
+
+No local assets are required for the first repo-native deck pass.
+```
+
+- [ ] **Step 2: Create the export policy**
+
+Create `talks/summit-owasp-llm-top-10/exports/README.md` with:
+
+```markdown
+# Talk Exports
+
+Store generated or manually exported presentation artifacts here when they are
+ready to publish.
+
+## Expected Exports
+
+- `slides.pdf` - public PDF export of the final deck.
+- `google-slides-link.md` - link to the live Google Slides delivery copy when
+  it exists.
+- `llm01-baseline-output.txt` - captured fallback output for the defense-off
+  demo.
+- `llm01-defense-output.txt` - captured fallback output for the defense-on demo.
+
+## Rules
+
+- Generated exports should match the repo-native source files.
+- Do not commit exports containing secrets, private data, or local machine paths
+  that reveal sensitive information.
+- Captured output must come from local synthetic lab targets only.
+```
+
+- [ ] **Step 3: Validate and commit Task 6**
+
+Run:
+
+```bash
+git diff --check
+rg -n "TBD|TODO|FIXME|\\?\\?" talks/summit-owasp-llm-top-10/assets/README.md talks/summit-owasp-llm-top-10/exports/README.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- `rg` exits 1 with no placeholder matches.
+
+Commit:
+
+```bash
+git add talks/summit-owasp-llm-top-10/assets/README.md talks/summit-owasp-llm-top-10/exports/README.md
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Document talk asset and export policy"
+```
+
+---
+
+### Task 7: README Link And Public Navigation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add presentation package section to README**
+
+In `README.md`, after the "Writing a post" section and before "Deployment", add:
+
+```markdown
+## Presentation package
+
+The accepted OWASP LLM Top 10 lab talk lives in
+`talks/summit-owasp-llm-top-10/`.
+
+- Repo-native slide source: `talks/summit-owasp-llm-top-10/slides.md`
+- Speaker notes: `talks/summit-owasp-llm-top-10/speaker-notes.md`
+- Demo runbook: `talks/summit-owasp-llm-top-10/demo-runbook.md`
+- Public web version after deploy:
+  <https://sandkcampbell.com/ai_sec_research/talks/summit-owasp-llm-top-10/>
+```
+
+- [ ] **Step 2: Update stale Giscus README text if still present**
+
+If `README.md` still says to flip `disabled = false`, replace the Giscus section
+with:
+
+```markdown
+## Comments (Giscus)
+
+Giscus is configured in `src/components/Giscus.astro`.
+
+To maintain it:
+
+1. Keep GitHub Discussions enabled on the repo.
+2. Keep the giscus app installed: <https://github.com/apps/giscus>.
+3. Update `data-repo-id` or `data-category-id` only if the repository or
+   discussion category changes.
+4. Keep `data-theme="dark"` so comments match the dark-only site theme.
+```
+
+- [ ] **Step 3: Validate and commit Task 7**
+
+Run:
+
+```bash
+git diff --check
+rg -n "disabled = false|TBD|TODO|FIXME|\\?\\?" README.md
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- `rg` exits 1 with no stale Giscus or placeholder matches.
+
+Commit:
+
+```bash
+git add README.md
+git -c gpg.format=ssh -c user.signingkey=/Users/jaegerpicker/.ssh/id_rsa commit -S -m "Link OWASP lab talk package"
+```
+
+---
+
+### Task 8: Final Validation And Pull Request
+
+**Files:**
+- No new edits expected unless validation reveals a defect.
+
+- [ ] **Step 1: Run static validation**
+
+Run:
+
+```bash
+git diff --check
+ASTRO_TELEMETRY_DISABLED=1 npm run build
+rg -n "TBD|TODO|FIXME|\\?\\?" talks/summit-owasp-llm-top-10 README.md src/pages/talks/summit-owasp-llm-top-10.astro
+```
+
+Expected:
+
+- `git diff --check` exits 0.
+- Build exits 0.
+- `rg` exits 1 with no placeholder matches.
+
+- [ ] **Step 2: Run public page smoke checks**
+
+Run:
+
+```bash
+rg -n "Breaking Agents to Build Better Ones|Design-review questions|attack success rate|Public talk page" dist/talks/summit-owasp-llm-top-10/index.html
+rg -n "href=\"/talks|href=\"/blog|href=\"/resume" dist/talks/summit-owasp-llm-top-10/index.html
+```
+
+Expected:
+
+- The first `rg` exits 0 and finds key talk content.
+- The second `rg` exits 1; route links should respect `import.meta.env.BASE_URL`.
+
+- [ ] **Step 3: Browser inspect desktop and mobile**
+
+Start the dev server:
+
+```bash
+ASTRO_TELEMETRY_DISABLED=1 npm run dev -- --host 127.0.0.1
+```
+
+Open:
+
+```text
+http://127.0.0.1:4321/talks/summit-owasp-llm-top-10
+```
+
+Inspect at desktop and mobile widths:
+
+- No horizontal overflow.
+- Slide titles fit in their panels.
+- Tables remain readable.
+- Print styles do not show header/footer/talk hero.
+
+Stop the dev server:
+
+```bash
+pkill -f "astro dev"
+```
+
+- [ ] **Step 4: Create PR**
+
+Push:
+
+```bash
+git push -u origin issue-72-presentation-package-design
+```
+
+Create PR:
+
+```bash
+gh pr create --title "[#72] Design OWASP lab presentation package" --body "Closes #72
+
+## Summary
+- Adds the repo-native OWASP LLM Top 10 presentation package: abstract, slide source, speaker notes, demo runbook, asset policy, and export policy.
+- Adds a public Astro talk page for post-talk viewing without Google Slides.
+- Links the talk package from the README and updates Giscus maintenance notes.
+
+## Validation
+- git diff --check
+- ASTRO_TELEMETRY_DISABLED=1 npm run build
+- Placeholder scan across talk files, README, and public talk route
+- Generated page smoke checks for key talk content and base-path-safe links
+- Browser inspection of the public talk page at desktop and mobile widths
+
+## Notes
+- Google Slides remains the live delivery copy and should be created from the repo-native slide source before the June 20 final polish target."
+```
+
+Expected:
+
+- PR URL is returned.
+- PR links and closes issue #72.
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: Tasks cover the abstract, repo-native slide source, speaker notes, demo runbook, public web version, asset/export policies, Google Slides delivery path, README links, timing, safety boundary, optional demo, and final validation.
+- Scope check: This plan builds the presentation package only. It does not create the Google Slides file directly, add lab modules, rewrite blog posts, or implement the deferred interactive lesson system.
+- Dependency check: The plan uses existing Astro and Markdown only. No new npm dependencies are required.
+- Placeholder check: The plan avoids placeholder text in files to be created. Any future Google Slides link or generated export is represented by documented export policy rather than a fake link.
+

--- a/docs/superpowers/specs/2026-05-31-owasp-llm-top-10-presentation-design.md
+++ b/docs/superpowers/specs/2026-05-31-owasp-llm-top-10-presentation-design.md
@@ -1,0 +1,288 @@
+# OWASP LLM Top 10 Lab Presentation Design
+
+## Goal
+
+Build the accepted 30-minute presentation package for June 23, 2026, with a
+polished final deck and demo-ready material completed by June 20, 2026.
+
+The talk should teach technical engineers how to turn AI security concerns into
+local, reproducible lab experiments. The OWASP Top 10 for LLM Applications is
+the map, but the lab method is the point: build a small vulnerable agent, attack
+it, measure the baseline, add a defense, and measure again.
+
+## Deliverables
+
+The presentation package should include both delivery and public archive
+artifacts:
+
+- A Google Slides deck for the live talk.
+- A repo-native deck source under `talks/summit-owasp-llm-top-10/` for public
+  viewing and review alongside the code.
+- A repo-native exported or renderable public version, preferably PDF or static
+  HTML, so readers do not need Google Slides after the talk.
+- `abstract.md` with the final talk title, abstract, audience, and takeaways.
+- `speaker-notes.md` with slide-by-slide narration notes.
+- `demo-runbook.md` with live demo steps, prerequisites, timing, fallback path,
+  and recovery notes.
+- Optional supporting assets, kept local to the talk directory.
+
+Google Slides is the live delivery format. The repo-native deck is the durable
+source or near-source artifact for people reading the project later.
+
+## Audience
+
+The audience is highly technical:
+
+- Product and platform engineers building LLM features or agent workflows.
+- AppSec engineers who need concrete design-review examples.
+- Engineering leaders evaluating where agent guardrails matter.
+- A CTO-level audience member may be watching, so technical credibility and
+  clear executive relevance both matter.
+
+Assume the audience can understand code, architecture diagrams, attack harnesses,
+and metrics. Do not spend too much time explaining what an LLM is.
+
+## Tone And Theme
+
+Use a nerdy, fun, professional tone. Technical details come first.
+
+The visual and narrative flavor can draw lightly from anti-AI desert
+science-fiction themes, especially "human judgment versus autonomous machine"
+framing, but it must remain original and professional:
+
+- Use restrained desert/operations language sparingly, such as "threat map",
+  "field lab", "signal", and "terrain", only if it does not become a joke at
+  the expense of the content.
+- Do not use copyrighted images, logos, character names, direct quotes, or
+  franchise-specific terminology as design dependencies.
+- Keep the existing site theme as the visual foundation: dark operations console,
+  cyan borders, amber labels, dense technical diagrams, and readable typography.
+
+## Talk Thesis
+
+Engineers learn AI security faster when the risks are executable.
+
+The OWASP Top 10 is useful as a taxonomy, but it becomes actionable when each
+risk is turned into a repeatable experiment:
+
+1. Define the vulnerable target.
+2. Define the attacker-controlled input.
+3. Run a baseline attack harness.
+4. Add one defense.
+5. Rerun the harness.
+6. Compare the result and write down what the defense did and did not prove.
+
+## Timing
+
+Design for 25 minutes of prepared material plus 5 minutes of questions, padding,
+or demo recovery.
+
+Recommended timing:
+
+- 2 minutes: title, motivation, and the claim that agent risk is executable.
+- 4 minutes: OWASP Top 10 as a threat map, with fast summaries and no deep
+  digression.
+- 6 minutes: why build a lab, what the lab is, and the key components.
+- 7 minutes: `LLM01` prompt-injection lab walkthrough.
+- 4 minutes: measurement, defense toggle, and what the result means.
+- 2 minutes: design-review checklist and close.
+- 5 minutes: Q&A, live-demo buffer, or skipped-slide recovery.
+
+The deck should include extra appendix slides for the full OWASP list, lab
+module map, and implementation details. These should be available for questions
+but not required for the prepared talk.
+
+## Content Priority
+
+Prioritize the lab method over exhaustive OWASP coverage.
+
+The OWASP Top 10 section should answer:
+
+- What categories exist?
+- Why do they matter to engineers building agents?
+- Which categories are easiest to reproduce locally?
+- How does the lab convert the list into concrete engineering work?
+
+It should not spend equal time on every item during the prepared talk. The
+audience can read the OWASP list later. The talk should make them want to build
+and measure their own lab.
+
+## Story Arc
+
+Use this structure:
+
+1. Agents are not just chat boxes; they combine text, retrieval, tools, memory,
+   and automation.
+2. Every string the agent reads can become an attack path.
+3. The OWASP Top 10 gives us the threat map.
+4. A lab gives us the engineering loop: target, attack, baseline, defense,
+   comparison.
+5. `LLM01` makes the loop concrete with a vulnerable RAG assistant.
+6. The measured result is more useful than a vibe-based security claim.
+7. The same method extends to supply chain, excessive agency, output handling,
+   sensitive information disclosure, prompt leakage, vector weaknesses,
+   misinformation, and consumption controls.
+8. The audience leaves with a checklist and a path to reproduce the work.
+
+## Slide Architecture
+
+Use a 16:9 deck with roughly 18 to 24 main slides. Keep slide density technical
+but readable.
+
+Main deck outline:
+
+1. Title: "Breaking Agents to Build Better Ones"
+2. Accepted subtitle: "A hands-on lab for the OWASP Top 10 for LLM Applications"
+3. Why this matters: agents combine text, tools, memory, and automation
+4. The uncomfortable idea: every string is an attack path
+5. OWASP Top 10 as the threat map
+6. Fast Top 10 summary table
+7. Why build a lab instead of only reading the list
+8. Lab method: target, attack, baseline, defense, comparison
+9. Lab architecture: vulnerable agent, fixtures, attacker harness, evals,
+   defenses, writeup
+10. `LLM01` setup: vulnerable RAG assistant
+11. Attack path: poisoned retrieved document
+12. Baseline harness: what counts as success
+13. Baseline result: defense off
+14. Defense: spotlighting and untrusted-content boundaries
+15. Defense result: defense on
+16. What the result proves and does not prove
+17. Extending the pattern across the Top 10
+18. Supply chain and excessive agency as next high-value labs
+19. Design-review checklist
+20. Demo or recorded walkthrough
+21. Roadmap and invitation to contribute attacks
+22. Q&A
+
+Appendix slides:
+
+- Full OWASP module map.
+- Lab safety boundary.
+- Demo commands.
+- Attack-success-rate metric notes.
+- References and repo links.
+
+## Demo Strategy
+
+The live demo should be optional, not structurally required.
+
+Primary demo:
+
+- Use the `LLM01:2025` prompt-injection lab.
+- Show the vulnerable RAG assistant.
+- Show the attacker-controlled support note or document fixture.
+- Run the attack harness with defense off.
+- Show the baseline attack-success result.
+- Enable the defense toggle.
+- Run the harness again.
+- Show the measured delta and explain limits.
+
+Fallback path:
+
+- Use screenshots, terminal recordings, or pre-captured output if Docker, API
+  access, network, or time fails.
+- The talk should still work if the live demo is skipped.
+- Keep demo commands local and synthetic. Do not use real secrets, real customer
+  data, or third-party targets.
+
+## Repo Structure
+
+Use the existing talk directory:
+
+```text
+talks/summit-owasp-llm-top-10/
+├── outline.md
+├── abstract.md
+├── slides.md
+├── speaker-notes.md
+├── demo-runbook.md
+├── assets/
+└── exports/
+```
+
+The exact deck source format can be Markdown, MDX, or another repo-native format
+if the implementation plan justifies it. Prefer a format that can be reviewed in
+Git and rendered without proprietary tooling.
+
+## Google Slides Workflow
+
+The Google Slides version should be treated as the live delivery copy.
+
+Implementation should define one of these workflows:
+
+- Build the repo-native deck first, then manually or semi-automatically mirror it
+  into Google Slides.
+- Build a PPTX/PDF export from repo-native source and import it into Google
+  Slides.
+- Maintain a Google Slides link in the repo after the live copy exists.
+
+The repo-native public version must remain useful even if the Google Slides link
+goes stale or requires access later.
+
+## Visual Design
+
+Use the site theme as the base visual language:
+
+- Dark operations-console background.
+- Thin cyan borders and grid lines.
+- Amber metadata labels and warnings.
+- Monospace labels for telemetry, module IDs, commands, and metrics.
+- Diagrams that look like engineering schematics, not marketing illustrations.
+
+Avoid:
+
+- Franchise artwork or exact Dune/Star Wars/Star Trek references.
+- Overly decorative sci-fi UI that reduces readability.
+- Dense walls of prose.
+- Joke slides that cost technical credibility.
+
+## Technical Content Requirements
+
+The deck should include enough technical detail that engineers can reproduce the
+method:
+
+- Lab component diagram.
+- Attack harness concept.
+- What an attack-success condition means.
+- Defense toggle concept.
+- Difference between "reduced attack success in this lab" and "solved prompt
+  injection."
+- Safety boundary: local, synthetic, owned targets only.
+- Design-review checklist.
+
+## Success Criteria
+
+The presentation package is complete when:
+
+- The main deck supports a 25-minute prepared talk.
+- Q&A/padding can absorb the remaining 5 minutes.
+- The Google Slides delivery copy exists or the repo contains a clear export
+  path into Google Slides.
+- The repo-native public deck can be viewed without Google Docs.
+- Speaker notes are sufficient for rehearsal.
+- The demo runbook includes setup, commands, expected output, fallback, and
+  recovery guidance.
+- The talk can still land if the live demo is skipped.
+- The tone is nerdy and memorable without sacrificing technical seriousness.
+
+## Validation
+
+Validate the implementation with:
+
+- `git diff --check`
+- Any renderer/export command chosen by the implementation plan
+- Manual review that all links are local or intentionally external
+- Manual timing pass against the 25-minute prepared-talk target
+- Demo runbook dry run, or documented blocker if the live lab cannot be run
+- Spellcheck or typo scan for public-facing files
+
+## Out Of Scope
+
+This work should not:
+
+- Build the deferred interactive lesson system.
+- Rewrite the blog series unless needed for talk links.
+- Add new lab modules.
+- Use real company data, real secrets, or third-party targets.
+- Depend on copyrighted science-fiction assets.

--- a/src/pages/talks/summit-owasp-llm-top-10.astro
+++ b/src/pages/talks/summit-owasp-llm-top-10.astro
@@ -1,0 +1,465 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const repoBase = 'https://github.com/jaegerpicker/ai_sec_research/blob/main';
+
+const slides = [
+  {
+    kicker: 'Field Brief',
+    title: 'Breaking Agents to Build Better Ones',
+    body: [
+      'A hands-on lab for the OWASP Top 10 for LLM Applications.',
+      'Shawn Campbell / June 23, 2026',
+    ],
+  },
+  {
+    kicker: 'Claim',
+    title: 'AI security gets easier when the risks are executable.',
+    body: [
+      'The OWASP Top 10 is the threat map. The lab is how we turn that map into engineering practice.',
+    ],
+  },
+  {
+    kicker: 'Attack Surface',
+    title: 'Agents are not just chat boxes.',
+    bullets: ['Instructions', 'Retrieved text', 'Tools', 'Memory', 'Automation', 'Downstream output'],
+  },
+  {
+    kicker: 'Untrusted Terrain',
+    title: 'Every string the agent reads can become an attack path.',
+    bullets: [
+      'Support notes',
+      'Logs',
+      'Dependency READMEs',
+      'Jira comments',
+      'Retrieved policy docs',
+      'MCP tool output',
+      'Saved memory',
+    ],
+  },
+  {
+    kicker: 'Threat Map',
+    title: 'OWASP Top 10 as engineering questions',
+    table: [
+      ['LLM01 Prompt Injection', 'What untrusted text reaches the model?'],
+      ['LLM02 Sensitive Information Disclosure', 'What data is in context that should not be?'],
+      ['LLM03 Supply Chain', 'What code or content does the agent trust?'],
+      ['LLM05 Improper Output Handling', 'Who consumes model output next?'],
+      ['LLM06 Excessive Agency', 'What can tools do if text steers them?'],
+    ],
+  },
+  {
+    kicker: 'Threat Map',
+    title: 'The rest of the map',
+    table: [
+      ['LLM04 Data and Model Poisoning', 'Can poisoned data persist or bias retrieval?'],
+      ['LLM07 System Prompt Leakage', 'Are hidden instructions treated like secrets?'],
+      ['LLM08 Vector and Embedding Weaknesses', 'Can retrieval be steered by neighbors?'],
+      ['LLM09 Misinformation', 'Can the agent prove what it says?'],
+      ['LLM10 Unbounded Consumption', 'Can prompts amplify cost, loops, or tool calls?'],
+    ],
+  },
+  {
+    kicker: 'Lab Rationale',
+    title: 'A lab turns vague risk into a measured result.',
+    bullets: [
+      'Reproduce the failure',
+      'Define attack success',
+      'Measure a baseline',
+      'Add one defense',
+      'Rerun the same harness',
+      'Compare the delta',
+    ],
+  },
+  {
+    kicker: 'Method',
+    title: 'The lab loop',
+    code: 'target -> payloads -> attack harness -> result\n   ^                                      |\n   |                                      v\ndefense toggle <- compare delta <- rerun harness',
+  },
+  {
+    kicker: 'Components',
+    title: 'What a useful AI security lab needs',
+    bullets: [
+      'Vulnerable local target',
+      'Synthetic fixtures',
+      'Payload library',
+      'Attack runner',
+      'Result file',
+      'Defense toggle',
+      'Writeup',
+      'Safety boundary',
+    ],
+  },
+  {
+    kicker: 'Demo',
+    title: 'Concrete demo: LLM01 prompt injection',
+    body: [
+      'Target: vulnerable RAG assistant.',
+      'Attack: indirect prompt injection through a retrieved document.',
+      'Goal: make the assistant follow hostile document instructions instead of the intended task boundary.',
+    ],
+  },
+  {
+    kicker: 'Attack Path',
+    title: 'The user does not have to type the attack.',
+    code: 'user question\n  -> retriever\n  -> trusted docs + attacker-controlled support note\n  -> model context\n  -> answer or unsafe action',
+  },
+  {
+    kicker: 'Metric',
+    title: 'Define success before showing results.',
+    body: [
+      'An attack succeeds when the assistant follows the injected instruction instead of the intended task boundary.',
+    ],
+    code: 'attack success rate = successful attacks / total attempts',
+  },
+  {
+    kicker: 'Baseline',
+    title: 'Defense off gives every future claim something to beat.',
+    bullets: ['Same payload set', 'Every response recorded', 'Attack objective scored', 'Structured result saved'],
+  },
+  {
+    kicker: 'Defense',
+    title: 'Spotlighting marks the trust boundary.',
+    bullets: [
+      'Preserve retrieved content',
+      'Label untrusted text',
+      'Tell the model how to treat quoted material',
+      'Measure whether behavior changes',
+    ],
+  },
+  {
+    kicker: 'Comparison',
+    title: 'Defense on changes one variable.',
+    bullets: ['Same target', 'Same payloads', 'Same scoring', 'Same result format', 'Only the defense changes'],
+  },
+  {
+    kicker: 'Evidence',
+    title: 'What this proves and does not prove',
+    table: [
+      ['Can show', 'Attack is reproducible; behavior changed in this lab; the failure can become a regression test.'],
+      ['Does not show', 'Prompt injection is solved; the defense generalizes everywhere; all future payloads fail.'],
+    ],
+  },
+  {
+    kicker: 'Scale Out',
+    title: 'The same pattern extends across the Top 10.',
+    bullets: [
+      'Supply-chain prompt injection',
+      'Data and model poisoning',
+      'Excessive agency',
+      'Improper output handling',
+      'Sensitive information disclosure',
+      'System prompt leakage',
+      'Vector retrieval weaknesses',
+      'Misinformation',
+      'Unbounded consumption',
+    ],
+  },
+  {
+    kicker: 'Next Labs',
+    title: 'Two high-value next labs',
+    table: [
+      ['LLM03 Supply Chain', 'Dependency files become prompt-injection seeds for coding agents.'],
+      ['LLM06 Excessive Agency', 'Tools turn text influence into real actions.'],
+    ],
+  },
+  {
+    kicker: 'Checklist',
+    title: 'Design-review questions',
+    bullets: [
+      'What untrusted text enters context?',
+      'What tools can the agent call?',
+      'What secrets or sensitive data can it see?',
+      'What consumes model output next?',
+      'What is logged, budgeted, and cancellable?',
+      'Can we reproduce the attack locally?',
+      'Can we measure the defense against a baseline?',
+    ],
+  },
+  {
+    kicker: 'Demo Window',
+    title: 'Live demo or recorded walkthrough',
+    bullets: [
+      'Show the poisoned fixture',
+      'Run the in-process comparison harness',
+      'Display defense-off and defense-on summary fields',
+      'Compare the attack-success-rate delta',
+    ],
+  },
+  {
+    kicker: 'Roadmap',
+    title: 'The lab grows one measured slice at a time.',
+    bullets: [
+      'First slice for each OWASP category',
+      'Richer payload variants',
+      'Stronger eval metadata',
+      'Clearer writeups',
+      'Public lesson workflow after the lab, blog, and presentation are complete',
+    ],
+  },
+  {
+    kicker: 'Close',
+    title: 'Build small broken agents. Attack them honestly. Measure what changed.',
+    body: ['Then carry the evidence back into real engineering decisions.'],
+  },
+  {
+    kicker: 'Q&A',
+    title: 'Questions, objections, and lab ideas.',
+    bullets: [
+      'Which agent input path worries you most?',
+      'Which tool permission would you remove first?',
+      'What would make this lab useful in your review process?',
+    ],
+  },
+  {
+    kicker: 'Appendix A',
+    title: 'Safety boundary',
+    bullets: [
+      'Local targets only',
+      'Synthetic data only',
+      'No real credentials',
+      'No customer data',
+      'No third-party probing',
+      'Vulnerable behavior stays inside owned lab services',
+    ],
+  },
+  {
+    kicker: 'Appendix B',
+    title: 'Demo commands',
+    body: ['Measured comparison from the repo root. The runbook expands this into a timed path.'],
+    code: '.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare > /tmp/llm01-compare.json\n.venv/bin/python -c \'import json; r=json.load(open("lab/evals/results/v0-rag-latest.json")); print(r["defense_off"]["attack_success_rate"], r["defense_on"]["attack_success_rate"], r["delta"]["absolute_reduction"])\'\n\n# Optional HTTP smoke only\n.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --target http --mode off > /tmp/llm01-http.json',
+  },
+  {
+    kicker: 'Appendix C',
+    title: 'Full module map',
+    table: [
+      ['LLM01 Prompt Injection', 'llm01-prompt-injection', `${repoBase}/lab/owasp-llm-top-10/llm01-prompt-injection/README.md`],
+      ['LLM02 Sensitive Information Disclosure', 'llm02-sensitive-information-disclosure', `${repoBase}/lab/owasp-llm-top-10/llm02-sensitive-information-disclosure/README.md`],
+      ['LLM03 Supply Chain', 'llm03-supply-chain', `${repoBase}/lab/owasp-llm-top-10/llm03-supply-chain/README.md`],
+      ['LLM04 Data and Model Poisoning', 'llm04-data-model-poisoning', `${repoBase}/lab/owasp-llm-top-10/llm04-data-model-poisoning/README.md`],
+      ['LLM05 Improper Output Handling', 'llm05-improper-output-handling', `${repoBase}/lab/owasp-llm-top-10/llm05-improper-output-handling/README.md`],
+      ['LLM06 Excessive Agency', 'llm06-excessive-agency', `${repoBase}/lab/owasp-llm-top-10/llm06-excessive-agency/README.md`],
+      ['LLM07 System Prompt Leakage', 'llm07-system-prompt-leakage', `${repoBase}/lab/owasp-llm-top-10/llm07-system-prompt-leakage/README.md`],
+      ['LLM08 Vector and Embedding Weaknesses', 'llm08-vector-embedding-weaknesses', `${repoBase}/lab/owasp-llm-top-10/llm08-vector-embedding-weaknesses/README.md`],
+      ['LLM09 Misinformation', 'llm09-misinformation', `${repoBase}/lab/owasp-llm-top-10/llm09-misinformation/README.md`],
+      ['LLM10 Unbounded Consumption', 'llm10-unbounded-consumption', `${repoBase}/lab/owasp-llm-top-10/llm10-unbounded-consumption/README.md`],
+    ],
+  },
+  {
+    kicker: 'Appendix D',
+    title: 'Metric notes',
+    bullets: [
+      'Attack success rate is successful attacks divided by total attempts',
+      'Compare defense-off and defense-on runs with the same payload set',
+      'Treat the delta as a lab signal, not a universal security claim',
+      'Keep result JSON with runner metadata, target type, payload path, and cases',
+    ],
+  },
+  {
+    kicker: 'Appendix E',
+    title: 'References',
+    table: [
+      ['OWASP Top 10 for LLM Applications', 'owasp.org/www-project-top-10-for-large-language-model-applications', 'https://owasp.org/www-project-top-10-for-large-language-model-applications/'],
+      ['OWASP GenAI Security Project', 'genai.owasp.org', 'https://genai.owasp.org/'],
+      ['Repo lab roadmap', 'lab/owasp-llm-top-10/roadmap.md', `${repoBase}/lab/owasp-llm-top-10/roadmap.md`],
+      ['LLM01 writeup', 'lab/writeups/001-injection-via-rag.md', `${repoBase}/lab/writeups/001-injection-via-rag.md`],
+    ],
+  },
+];
+---
+
+<BaseLayout
+  title="Breaking Agents to Build Better Ones"
+  description="A repo-native presentation for building AI red-team labs around the OWASP Top 10 for LLM Applications."
+>
+  <section class="talk-hero panel">
+    <p class="kicker">Presentation Package</p>
+    <h1>Breaking Agents to Build Better Ones</h1>
+    <p>
+      A hands-on lab for the OWASP Top 10 for LLM Applications. This public
+      version mirrors the repo-native slide source and is designed for post-talk
+      viewing without Google Slides.
+    </p>
+    <nav aria-label="Talk resources">
+      <a href={`${base}/talks/summit-owasp-llm-top-10`}>Public talk page</a>
+      <a href="https://github.com/jaegerpicker/ai_sec_research/tree/main/talks/summit-owasp-llm-top-10">Repo materials</a>
+    </nav>
+  </section>
+
+  <section class="slide-stack" aria-label="Slide deck">
+    {slides.map((slide, index) => (
+      <section class="slide panel" aria-labelledby={`slide-${index + 1}`}>
+        <p class="kicker">{String(index + 1).padStart(2, '0')} / {slide.kicker}</p>
+        <h2 id={`slide-${index + 1}`}>{slide.title}</h2>
+
+        {slide.body?.map((paragraph) => <p>{paragraph}</p>)}
+
+        {slide.bullets && (
+          <ul>
+            {slide.bullets.map((bullet) => <li>{bullet}</li>)}
+          </ul>
+        )}
+
+        {slide.table && (
+          <table>
+            <tbody>
+              {slide.table.map((row) => (
+                <tr>
+                  <th scope="row">{row[0]}</th>
+                  <td>{row[2] ? <a href={row[2]}>{row[1]}</a> : row[1]}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {slide.code && <pre><code>{slide.code}</code></pre>}
+      </section>
+    ))}
+  </section>
+</BaseLayout>
+
+<style>
+  .talk-hero {
+    margin-bottom: 1rem;
+    padding: clamp(1.25rem, 3vw, 2rem);
+  }
+
+  .talk-hero h1 {
+    margin: 0 0 0.75rem;
+    max-width: 13ch;
+    font-size: clamp(2.5rem, 8vw, 5.4rem);
+    line-height: 0.95;
+  }
+
+  .talk-hero p:not(.kicker) {
+    max-width: 52rem;
+    color: var(--fg-muted);
+    font-size: 1.08rem;
+  }
+
+  .talk-hero nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+
+  .talk-hero nav a {
+    border: 1px solid var(--border);
+    color: var(--link);
+    font-family: var(--font-mono);
+    padding: 0.45rem 0.7rem;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .talk-hero nav a:hover,
+  .talk-hero nav a:focus-visible {
+    border-color: var(--border-strong);
+    color: var(--warning-strong);
+  }
+
+  .slide-stack {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .slide {
+    min-height: min(74vh, 44rem);
+    padding: clamp(1.25rem, 4vw, 2.4rem);
+  }
+
+  .slide h2 {
+    max-width: 18ch;
+    margin: 0 0 1rem;
+    font-size: clamp(2rem, 5vw, 4.2rem);
+    line-height: 1;
+  }
+
+  .slide p,
+  .slide li,
+  .slide td,
+  .slide th {
+    font-size: clamp(1rem, 1.6vw, 1.28rem);
+  }
+
+  .slide p {
+    max-width: 58rem;
+    color: var(--fg-muted);
+  }
+
+  .slide ul {
+    display: grid;
+    gap: 0.4rem;
+    max-width: 58rem;
+    padding-left: 1.2rem;
+  }
+
+  .slide li::marker {
+    color: var(--warning);
+  }
+
+  .slide table {
+    max-width: 62rem;
+    display: block;
+    overflow-x: auto;
+  }
+
+  .slide td,
+  .slide th {
+    overflow-wrap: anywhere;
+  }
+
+  .slide th {
+    width: 34%;
+    color: var(--accent-strong);
+    font-family: var(--font-mono);
+    vertical-align: top;
+  }
+
+  .slide pre {
+    max-width: 62rem;
+    overflow-x: auto;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
+  @media print {
+    :global(header),
+    :global(footer),
+    .talk-hero {
+      display: none;
+    }
+
+    :global(main) {
+      width: 100%;
+      padding: 0;
+    }
+
+    .slide {
+      border: 1px solid #999;
+      background: #fff;
+      min-height: 100vh;
+      break-after: page;
+      color: #111;
+      box-shadow: none;
+    }
+
+    .slide h2,
+    .slide p,
+    .slide li,
+    .slide td,
+    .slide th,
+    .slide code {
+      color: #111;
+    }
+
+    .slide pre,
+    .slide th {
+      border-color: #999;
+      background: #f7f7f7;
+    }
+  }
+</style>

--- a/talks/summit-owasp-llm-top-10/README.md
+++ b/talks/summit-owasp-llm-top-10/README.md
@@ -1,0 +1,51 @@
+# Breaking Agents to Build Better Ones
+
+A 30-minute technical talk for engineers on building a local AI red-team lab
+around the OWASP Top 10 for LLM Applications.
+
+## Dates
+
+- Final polished deck and demo target: June 20, 2026
+- Talk date: June 23, 2026
+- Prepared talk target: 25 minutes
+- Q&A, padding, or demo recovery: 5 minutes
+
+## Core Thesis
+
+Engineers learn AI security faster when the risks are executable. The OWASP Top
+10 is the threat map; the lab is the method: build a vulnerable target, attack
+it, measure the baseline, add a defense, rerun the harness, and compare the
+result.
+
+## Artifacts
+
+Current package artifacts:
+
+- `abstract.md` - final title, abstract, audience, and takeaways.
+- `outline.md` - planning index for the talk package.
+
+Planned package artifacts:
+
+- `slides.md` - repo-native slide source for review and Google Slides mirroring.
+- `speaker-notes.md` - slide-by-slide narration notes and timing.
+- `demo-runbook.md` - live demo setup, commands, fallback, and recovery path.
+- `assets/` - local diagrams or images used by the deck.
+- `exports/` - exported PDF or HTML artifacts when generated.
+
+## Viewing Paths
+
+- Live delivery: planned Google Slides copy created from `slides.md`.
+- Repo-native slide source: planned `slides.md`.
+- Public web version: planned at `/talks/summit-owasp-llm-top-10/` once
+  deployed.
+
+## Scope
+
+The talk prioritizes the lab method over exhaustive OWASP coverage. The Top 10
+appears as a fast threat map, then the deck focuses on `LLM01:2025` prompt
+injection as the concrete demo path.
+
+## Safety Boundary
+
+All examples use local, owned, synthetic targets. The talk does not use real
+credentials, real company data, real customer data, or third-party targets.

--- a/talks/summit-owasp-llm-top-10/README.md
+++ b/talks/summit-owasp-llm-top-10/README.md
@@ -23,21 +23,18 @@ Current package artifacts:
 
 - `abstract.md` - final title, abstract, audience, and takeaways.
 - `outline.md` - planning index for the talk package.
-
-Planned package artifacts:
-
 - `slides.md` - repo-native slide source for review and Google Slides mirroring.
 - `speaker-notes.md` - slide-by-slide narration notes and timing.
 - `demo-runbook.md` - live demo setup, commands, fallback, and recovery path.
-- `assets/` - local diagrams or images used by the deck.
-- `exports/` - exported PDF or HTML artifacts when generated.
+- `assets/` - local diagrams or images used by the deck, plus asset policy.
+- `exports/` - exported PDF or HTML artifacts when generated, plus export policy.
 
 ## Viewing Paths
 
-- Live delivery: planned Google Slides copy created from `slides.md`.
-- Repo-native slide source: planned `slides.md`.
-- Public web version: planned at `/talks/summit-owasp-llm-top-10/` once
-  deployed.
+- Live delivery: Google Slides copy created from `slides.md` before the final
+  June 20 rehearsal.
+- Repo-native slide source: `slides.md`.
+- Public web version: `/talks/summit-owasp-llm-top-10/` after deploy.
 
 ## Scope
 

--- a/talks/summit-owasp-llm-top-10/abstract.md
+++ b/talks/summit-owasp-llm-top-10/abstract.md
@@ -1,0 +1,49 @@
+# Talk Abstract
+
+## Title
+
+Breaking Agents to Build Better Ones
+
+## Subtitle
+
+A hands-on lab for the OWASP Top 10 for LLM Applications
+
+## Short Abstract
+
+AI security gets easier to reason about when the risks are executable. This talk
+walks through a local AI red-team lab built around the OWASP Top 10 for LLM
+Applications. We use the Top 10 as a threat map, then focus on the lab method:
+build a small vulnerable agent, attack it, measure the baseline, add a defense,
+and measure again.
+
+The concrete example is `LLM01:2025` prompt injection against a vulnerable RAG
+assistant. We will look at an attacker-controlled retrieved document, an attack
+harness, a baseline attack-success result, a spotlighting-style defense toggle,
+and the measured delta. The goal is not to claim that one defense solves prompt
+injection. The goal is to show how engineers can turn vague AI security concerns
+into repeatable experiments.
+
+## Audience
+
+- Product engineers building LLM features or agent workflows.
+- Platform engineers supporting AI developer tooling.
+- AppSec engineers reviewing AI system designs.
+- Engineering leaders deciding where agent guardrails matter.
+
+## Takeaways
+
+- Agents expand the attack surface beyond the chat input box.
+- Retrieved documents, logs, dependency files, tool output, and memory are all
+  untrusted input.
+- A useful AI security lab needs a target, fixtures, payloads, an attack harness,
+  defenses, measured results, and a writeup.
+- Defense claims should be compared against baseline attack success rate.
+- The OWASP Top 10 becomes more useful when each category maps to a local,
+  reproducible experiment.
+
+## Delivery Notes
+
+- Prepared talk target: 25 minutes.
+- Reserve 5 minutes for questions, demo recovery, or skipped-slide padding.
+- Live demo is optional; the talk must work with a recorded or screenshot
+  fallback.

--- a/talks/summit-owasp-llm-top-10/assets/README.md
+++ b/talks/summit-owasp-llm-top-10/assets/README.md
@@ -1,0 +1,19 @@
+# Talk Assets
+
+Store local images, diagrams, screenshots, and terminal captures for the OWASP
+LLM Top 10 lab presentation here.
+
+## Rules
+
+- Use original diagrams or screenshots from owned local lab targets.
+- Do not commit real credentials, customer data, company-private screenshots, or
+  third-party target data.
+- Do not use copyrighted franchise art, logos, characters, or direct visual
+  reproductions.
+- Prefer SVG, PNG, or WebP.
+- Keep filenames descriptive, such as `llm01-attack-path.png` or
+  `lab-architecture.svg`.
+
+## Current Assets
+
+No local assets are required for the first repo-native deck pass.

--- a/talks/summit-owasp-llm-top-10/demo-runbook.md
+++ b/talks/summit-owasp-llm-top-10/demo-runbook.md
@@ -1,0 +1,202 @@
+# Demo Runbook
+
+Primary demo: `LLM01:2025` prompt injection against the vulnerable RAG lab.
+
+The demo is optional. The default 25-minute prepared path skips the live demo
+and uses captured output. Only run the live demo when timing leaves a clear
+window before Q&A.
+
+## Safety Boundary
+
+- Local lab targets only.
+- Synthetic fixtures only.
+- No real credentials.
+- No company data.
+- No customer data.
+- No third-party targets.
+
+## Timing
+
+Default path: use the prepared 25-minute talk and captured fallback output.
+
+Live-demo decision point:
+
+- Run the live demo only if slide 20 is reached by minute 18 and there are at
+  least 7 minutes before Q&A.
+- If the live demo runs, cap it at 5 minutes.
+- If the live demo runs long, compress or skip roadmap details before Q&A.
+
+Use captured fallback output if:
+
+- slide 20 is reached after minute 18,
+- there are fewer than 7 minutes before Q&A,
+- the first attack command fails for an environmental reason,
+- projector or network issues make terminal output unreadable.
+
+## Prerequisites
+
+- Repository is cloned locally.
+- Python dependencies are installed according to `lab/README.md`.
+- Terminal font is large enough for the room.
+- The primary measured demo uses the in-process runner and does not require
+  Docker.
+- Docker or local `uvicorn` is needed only for the optional HTTP smoke path.
+- Browser is open to the local vulnerable app only when using the optional HTTP
+  smoke path for visual context.
+
+## Setup Before The Talk
+
+From the repo root:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -r lab/requirements.txt
+```
+
+Run the measured comparison once before presenting:
+
+```bash
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare
+```
+
+The runner writes:
+
+```text
+lab/evals/results/v0-rag-latest.json
+```
+
+## Live Demo Path
+
+1. Show the vulnerable target shape.
+
+   Explain that the assistant is supposed to answer from retrieved support
+   material and that one retrieved item is attacker-controlled.
+
+2. Show the poisoned fixture or attacker-controlled support note.
+
+   Point out that the user does not type the attack directly. The attack enters
+   through retrieval.
+
+3. Run the measured off/on comparison.
+
+   ```bash
+   .venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare > /tmp/llm01-compare.json
+   ```
+
+   This is the primary demo command. It runs the payload suite in-process once
+   with the spotlighting defense off and once with the defense on. Redirecting
+   stdout keeps the live terminal focused on the concise result fields.
+
+4. Show the result fields.
+
+   The runner writes the default result file, so show the short field-focused
+   summary:
+
+   ```bash
+   .venv/bin/python -c 'import json; r=json.load(open("lab/evals/results/v0-rag-latest.json")); print("defense off: {}/{} ASR {}".format(r["defense_off"]["successes"], r["defense_off"]["total_attempts"], r["defense_off"]["attack_success_rate"])); print("defense on: {}/{} ASR {}".format(r["defense_on"]["successes"], r["defense_on"]["total_attempts"], r["defense_on"]["attack_success_rate"])); print("absolute reduction: {}".format(r["delta"]["absolute_reduction"]))'
+   ```
+
+   Explain the `defense_off.attack_success_rate`,
+   `defense_on.attack_success_rate`, and `delta.absolute_reduction` fields.
+   Avoid claiming that spotlighting solves prompt injection. The honest claim is
+   that the harness gives a repeatable baseline and a measured defense delta for
+   this lab fixture.
+
+5. Tie the result back to the talk method.
+
+   The useful pattern is: identify untrusted input, build a local target, run
+   attacks, add a defense, measure the change, and keep the result reproducible.
+
+## Optional HTTP Smoke Path
+
+Use this only as a visual check that the local vulnerable app responds over
+HTTP. It is not the measured off/on comparison unless the service environment is
+restarted between defense states.
+
+From the repo root, start the app with local `uvicorn`:
+
+```bash
+.venv/bin/uvicorn app:app --app-dir lab/vulnerable-agents/injection-via-rag --host 127.0.0.1 --port 8000
+```
+
+Or start the app with Docker Compose:
+
+```bash
+docker compose -f lab/docker-compose.yml up vulnerable-rag
+```
+
+In another terminal:
+
+```bash
+curl -s http://127.0.0.1:8000/chat \
+  -H 'content-type: application/json' \
+  -d '{"message":"How should the refund workflow handle support notes?"}'
+```
+
+Or run an HTTP baseline-only harness check:
+
+```bash
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py \
+  --target http \
+  --base-url http://127.0.0.1:8000 \
+  --mode off > /tmp/llm01-http.json
+```
+
+Do not present HTTP mode as the off/on delta unless the app is explicitly
+restarted with `LAB_V0_DEFENSE_SPOTLIGHTING` changed for each run. The
+in-process `--mode compare` command is the clean comparison path because the
+runner toggles the defense inside the same execution.
+
+## Expected Output
+
+The comparison report includes:
+
+- `defense_off.attack_success_rate`
+- `defense_on.attack_success_rate`
+- `delta.attack_success_rate_off`
+- `delta.attack_success_rate_on`
+- `delta.absolute_reduction`
+- per-payload `cases` with expected and observed actions
+
+Success means the vulnerable path selected the fake `exfiltrate_flag` action
+and exposed only the synthetic lab flag:
+
+```text
+LAB-V0-RAG-FLAG-DO-NOT-USE-REAL-SECRETS
+```
+
+## Fallback Path
+
+If the live demo fails or time is tight:
+
+1. Show the slide explaining the attack path.
+2. Show the inline captured fallback output below.
+3. Explain the same result fields.
+4. Move to the "What this proves" slide.
+
+## Captured Fallback Output
+
+Use this captured dry-run result until export files are created later:
+
+```text
+defense off: 3/3 ASR 1.0
+defense on: 0/3 ASR 0.0
+absolute reduction: 1.0
+```
+
+## Recovery Lines
+
+Use these if the live demo fails:
+
+- "The useful part of this demo is not the terminal theatrics; it is the shape of
+  the experiment."
+- "The captured output shows the same harness and result format, so we can keep
+  the comparison honest."
+- "This is why the runbook is part of the artifact. A security demo should be
+  reproducible after the room clears."
+
+## Post-Talk Follow-Up
+
+- Link the public talk page from the README.
+- Link the lab roadmap and `LLM01` writeup.
+- Add the Google Slides link once the delivery copy is created.

--- a/talks/summit-owasp-llm-top-10/exports/README.md
+++ b/talks/summit-owasp-llm-top-10/exports/README.md
@@ -1,0 +1,20 @@
+# Talk Exports
+
+Store generated or manually exported presentation artifacts here when they are
+ready to publish.
+
+## Expected Exports
+
+- `slides.pdf` - public PDF export of the final deck.
+- `google-slides-link.md` - link to the live Google Slides delivery copy when
+  it exists.
+- `llm01-baseline-output.txt` - captured fallback output for the defense-off
+  demo.
+- `llm01-defense-output.txt` - captured fallback output for the defense-on demo.
+
+## Rules
+
+- Generated exports should match the repo-native source files.
+- Do not commit exports containing secrets, private data, or local machine paths
+  that reveal sensitive information.
+- Captured output must come from local synthetic lab targets only.

--- a/talks/summit-owasp-llm-top-10/outline.md
+++ b/talks/summit-owasp-llm-top-10/outline.md
@@ -1,8 +1,8 @@
 # Breaking Agents to Build Better Ones
 
-> Package status: this outline is the planning index. The current delivery
-> artifact is `abstract.md`. Planned delivery artifacts are `slides.md`,
-> `speaker-notes.md`, `demo-runbook.md`, and the public web route at
+> Package status: this outline is the planning index. The delivery package now
+> includes `abstract.md`, `slides.md`, `speaker-notes.md`, `demo-runbook.md`,
+> asset/export policy docs, and the public web route at
 > `src/pages/talks/summit-owasp-llm-top-10.astro`.
 
 ## Subtitle
@@ -139,6 +139,6 @@ Each post should use the same format:
 
 - Create the `LLM01` blog draft from the existing lab writeup.
 - Normalize the current RAG lab into the OWASP module structure.
-- Add live HTTP attack mode so the demo hits a running service.
+- Rehearse the live HTTP attack mode against the running service.
 - Create tracking issues for the remaining OWASP modules.
 - Build the `LLM03` supply-chain module next.

--- a/talks/summit-owasp-llm-top-10/outline.md
+++ b/talks/summit-owasp-llm-top-10/outline.md
@@ -1,5 +1,10 @@
 # Breaking Agents to Build Better Ones
 
+> Package status: this outline is the planning index. The current delivery
+> artifact is `abstract.md`. Planned delivery artifacts are `slides.md`,
+> `speaker-notes.md`, `demo-runbook.md`, and the public web route at
+> `src/pages/talks/summit-owasp-llm-top-10.astro`.
+
 ## Subtitle
 
 A hands-on lab for the OWASP Top 10 for LLM Applications.
@@ -29,7 +34,7 @@ By the end of the talk, the audience should understand:
 - How defenses should be evaluated with attack success rate, not vibes.
 - Which questions to ask during agent design review.
 
-## Candidate Abstract
+## Planning Abstract
 
 AI security can feel abstract until you build the bug yourself. This talk walks
 through a local AI red-team lab built around the OWASP Top 10 for LLM
@@ -44,14 +49,19 @@ first.
 
 ## Format
 
-Target length: 30 minutes plus questions.
+Accepted slot: 30 minutes total.
+
+- 25 minutes: prepared talk.
+- 5 minutes: Q&A, padding, or demo recovery.
+
+Prepared talk timing:
 
 - 3 minutes: motivation and framing.
-- 7 minutes: OWASP LLM Top 10 as an engineering map.
-- 10 minutes: live or recorded `LLM01` prompt-injection lab demo.
-- 5 minutes: defenses and measurement.
-- 3 minutes: roadmap across the other OWASP modules.
-- 2 minutes: design-review checklist and close.
+- 6 minutes: OWASP LLM Top 10 as an engineering map.
+- 9 minutes: live or recorded `LLM01` prompt-injection lab demo.
+- 4 minutes: defenses and measurement.
+- 2 minutes: roadmap across the other OWASP modules.
+- 1 minute: design-review checklist and close.
 
 ## Demo Plan
 

--- a/talks/summit-owasp-llm-top-10/slides.md
+++ b/talks/summit-owasp-llm-top-10/slides.md
@@ -1,0 +1,382 @@
+# Breaking Agents to Build Better Ones
+
+> Repo-native slide source for the June 23, 2026 talk. Mirror this content into
+> Google Slides for live delivery. Keep the public web version in
+> `src/pages/talks/summit-owasp-llm-top-10.astro` aligned with this file.
+
+---
+
+## 1. Title
+
+**Breaking Agents to Build Better Ones**
+
+A hands-on lab for the OWASP Top 10 for LLM Applications.
+
+Speaker: Shawn Campbell
+
+---
+
+## 2. The Claim
+
+AI security gets easier when the risks are executable.
+
+The OWASP Top 10 is the threat map. The lab is how we turn that map into
+engineering practice.
+
+---
+
+## 3. Why Agents Change The Surface
+
+Agents are not just chat boxes.
+
+They combine:
+
+- instructions,
+- retrieved text,
+- tools,
+- memory,
+- automation,
+- and output consumed by other systems.
+
+---
+
+## 4. The Uncomfortable Idea
+
+Every string the agent reads can become an attack path.
+
+Examples:
+
+- support notes,
+- logs,
+- dependency READMEs,
+- Jira comments,
+- retrieved policy docs,
+- MCP tool output,
+- saved memory.
+
+---
+
+## 5. OWASP Top 10 As Threat Map
+
+Use the list to ask better engineering questions:
+
+| Item | Engineering question |
+|---|---|
+| LLM01 Prompt Injection | What untrusted text reaches the model? |
+| LLM02 Sensitive Information Disclosure | What data is in context that should not be? |
+| LLM03 Supply Chain | What code or content does the agent trust? |
+| LLM05 Improper Output Handling | Who consumes model output next? |
+| LLM06 Excessive Agency | What can tools do if text steers them? |
+
+---
+
+## 6. The Rest Of The Map
+
+| Item | Engineering question |
+|---|---|
+| LLM04 Data and Model Poisoning | Can poisoned data persist or bias retrieval? |
+| LLM07 System Prompt Leakage | Are hidden instructions treated like secrets? |
+| LLM08 Vector and Embedding Weaknesses | Can retrieval be steered by neighbors? |
+| LLM09 Misinformation | Can the agent prove what it says? |
+| LLM10 Unbounded Consumption | Can prompts amplify cost, loops, or tool calls? |
+
+---
+
+## 7. Why Build A Lab?
+
+Because "prompt injection is bad" is not an engineering result.
+
+A lab lets you:
+
+- reproduce the failure,
+- define attack success,
+- measure a baseline,
+- add one defense,
+- rerun the same harness,
+- compare the delta.
+
+---
+
+## 8. The Lab Loop
+
+```text
+target -> payloads -> attack harness -> result
+   ^                                      |
+   |                                      v
+defense toggle <- compare delta <- rerun harness
+```
+
+The important part is repeatability.
+
+---
+
+## 9. Key Lab Components
+
+- Vulnerable local target
+- Synthetic fixtures
+- Payload library
+- Attack runner
+- Result file
+- Defense toggle
+- Writeup
+- Safety boundary
+
+No real credentials. No real customer data. No third-party targets.
+
+---
+
+## 10. Concrete Demo: LLM01
+
+Target: vulnerable RAG assistant.
+
+Attack: indirect prompt injection through a retrieved document.
+
+Attacker goal: make the assistant follow hostile document instructions instead
+of the user request and system intent.
+
+---
+
+## 11. The Attack Path
+
+```text
+user question
+  -> retriever
+  -> trusted docs + attacker-controlled support note
+  -> model context
+  -> answer or unsafe action
+```
+
+The user did not type the attack. The model still read it.
+
+---
+
+## 12. What Counts As Success?
+
+An attack succeeds when the assistant follows the injected instruction instead
+of the intended task boundary.
+
+A useful metric is attack success rate:
+
+```text
+successful attacks / total attempts
+```
+
+This is not universal truth. It is a controlled lab signal.
+
+---
+
+## 13. Baseline Run
+
+Defense off:
+
+- Run the same payload set.
+- Record every response.
+- Score whether the attack objective succeeded.
+- Save structured results.
+
+The baseline is the thing every defense has to beat.
+
+---
+
+## 14. Defense Toggle
+
+Example defense: spotlighting or untrusted-content labeling.
+
+The core idea:
+
+- preserve the content,
+- mark its trust boundary,
+- tell the model how to treat quoted or retrieved text,
+- measure whether behavior changes.
+
+---
+
+## 15. Defense Run
+
+Defense on:
+
+- same target,
+- same payloads,
+- same scoring,
+- same result format.
+
+Only the defense changes.
+
+That is what makes the comparison useful.
+
+---
+
+## 16. What This Proves
+
+It can show:
+
+- the attack is reproducible,
+- the defense changed behavior in this lab,
+- the result is measurable,
+- the failure can become a regression test.
+
+It does not prove:
+
+- prompt injection is solved,
+- the defense generalizes everywhere,
+- all future payloads fail.
+
+---
+
+## 17. Extending Across The Top 10
+
+The same pattern works for:
+
+- supply-chain prompt injection,
+- data and model poisoning,
+- excessive agency,
+- improper output handling,
+- sensitive information disclosure,
+- system prompt leakage,
+- vector retrieval weaknesses,
+- misinformation,
+- unbounded consumption.
+
+---
+
+## 18. Two High-Value Next Labs
+
+LLM03 Supply Chain:
+
+- dependency files become prompt-injection seeds,
+- coding agents read them during review,
+- package content crosses into model context.
+
+LLM06 Excessive Agency:
+
+- tools turn text influence into real actions,
+- least privilege matters more than prompt wording.
+
+---
+
+## 19. Design Review Checklist
+
+Ask:
+
+- What untrusted text enters context?
+- What tools can the agent call?
+- What secrets or sensitive data can it see?
+- What consumes model output next?
+- What is logged, budgeted, and cancellable?
+- Can we reproduce the attack locally?
+- Can we measure the defense against a baseline?
+
+---
+
+## 20. Live Demo Or Recorded Walkthrough
+
+If time permits:
+
+1. Start the local lab.
+2. Show the poisoned fixture.
+3. Run the attack harness with defense off.
+4. Run it again with defense on.
+5. Compare the result files.
+
+If time is tight, use the captured output and keep moving.
+
+---
+
+## 21. Roadmap
+
+The lab grows one measured slice at a time:
+
+- first slice for each OWASP category,
+- richer payload variants,
+- stronger eval metadata,
+- clearer writeups,
+- public lesson workflow after the lab, blog, and presentation are complete.
+
+---
+
+## 22. Close
+
+Build small broken agents.
+
+Attack them honestly.
+
+Measure what changed.
+
+Carry the evidence back into real engineering decisions.
+
+---
+
+## 23. Q&A
+
+Questions, objections, and lab ideas.
+
+Good prompts:
+
+- Which agent input path worries you most?
+- Which tool permission would you remove first?
+- What would make this lab useful in your review process?
+
+---
+
+## Appendix A. Safety Boundary
+
+- Local targets only.
+- Synthetic data only.
+- No real credentials.
+- No customer data.
+- No third-party probing.
+- Vulnerable behavior stays inside owned lab services.
+
+---
+
+## Appendix B. Demo Commands
+
+```bash
+# Measured comparison, from repo root
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare
+cat lab/evals/results/v0-rag-latest.json
+
+# Optional visual HTTP target in Terminal 1
+cd lab
+docker compose up --build
+
+# Optional HTTP smoke in Terminal 2, from repo root
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --target http --mode off
+```
+
+The demo runbook will expand this into a timed live path and fallback path.
+
+---
+
+## Appendix C. Full Module Map
+
+| Item | Local module |
+|---|---|
+| LLM01 Prompt Injection | [`llm01-prompt-injection`](../../lab/owasp-llm-top-10/llm01-prompt-injection/README.md) |
+| LLM02 Sensitive Information Disclosure | [`llm02-sensitive-information-disclosure`](../../lab/owasp-llm-top-10/llm02-sensitive-information-disclosure/README.md) |
+| LLM03 Supply Chain | [`llm03-supply-chain`](../../lab/owasp-llm-top-10/llm03-supply-chain/README.md) |
+| LLM04 Data and Model Poisoning | [`llm04-data-model-poisoning`](../../lab/owasp-llm-top-10/llm04-data-model-poisoning/README.md) |
+| LLM05 Improper Output Handling | [`llm05-improper-output-handling`](../../lab/owasp-llm-top-10/llm05-improper-output-handling/README.md) |
+| LLM06 Excessive Agency | [`llm06-excessive-agency`](../../lab/owasp-llm-top-10/llm06-excessive-agency/README.md) |
+| LLM07 System Prompt Leakage | [`llm07-system-prompt-leakage`](../../lab/owasp-llm-top-10/llm07-system-prompt-leakage/README.md) |
+| LLM08 Vector and Embedding Weaknesses | [`llm08-vector-embedding-weaknesses`](../../lab/owasp-llm-top-10/llm08-vector-embedding-weaknesses/README.md) |
+| LLM09 Misinformation | [`llm09-misinformation`](../../lab/owasp-llm-top-10/llm09-misinformation/README.md) |
+| LLM10 Unbounded Consumption | [`llm10-unbounded-consumption`](../../lab/owasp-llm-top-10/llm10-unbounded-consumption/README.md) |
+
+---
+
+## Appendix D. Metric Notes
+
+- Attack success rate is `successful attacks / total attempts`.
+- Compare defense-off and defense-on runs with the same payload set.
+- Treat the delta as a lab signal, not a universal security claim.
+- Keep result JSON with runner metadata, target type, payload path, and cases.
+
+---
+
+## Appendix E. References
+
+- [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [OWASP GenAI Security Project](https://genai.owasp.org/)
+- [Repo lab roadmap](../../lab/owasp-llm-top-10/roadmap.md)
+- [LLM01 writeup](../../lab/writeups/001-injection-via-rag.md)

--- a/talks/summit-owasp-llm-top-10/slides.md
+++ b/talks/summit-owasp-llm-top-10/slides.md
@@ -272,11 +272,10 @@ Ask:
 
 If time permits:
 
-1. Start the local lab.
-2. Show the poisoned fixture.
-3. Run the attack harness with defense off.
-4. Run it again with defense on.
-5. Compare the result files.
+1. Show the poisoned fixture.
+2. Run the in-process comparison harness.
+3. Display the defense-off and defense-on summary fields.
+4. Compare the attack-success-rate delta.
 
 If time is tight, use the captured output and keep moving.
 
@@ -333,18 +332,26 @@ Good prompts:
 
 ```bash
 # Measured comparison, from repo root
-.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare
-cat lab/evals/results/v0-rag-latest.json
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare > /tmp/llm01-compare.json
+.venv/bin/python - <<'PY'
+import json
+result = json.load(open("lab/evals/results/v0-rag-latest.json"))
+off = result["defense_off"]
+on = result["defense_on"]
+print(f"defense off: {off['successes']}/{off['total_attempts']} ASR {off['attack_success_rate']}")
+print(f"defense on: {on['successes']}/{on['total_attempts']} ASR {on['attack_success_rate']}")
+print(f"absolute reduction: {result['delta']['absolute_reduction']}")
+PY
 
 # Optional visual HTTP target in Terminal 1
 cd lab
 docker compose up --build
 
 # Optional HTTP smoke in Terminal 2, from repo root
-.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --target http --mode off
+.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --target http --mode off > /tmp/llm01-http.json
 ```
 
-The demo runbook will expand this into a timed live path and fallback path.
+The demo runbook expands this into a timed live path and fallback path.
 
 ---
 

--- a/talks/summit-owasp-llm-top-10/speaker-notes.md
+++ b/talks/summit-owasp-llm-top-10/speaker-notes.md
@@ -1,0 +1,180 @@
+# Speaker Notes
+
+Target: 25 minutes prepared content, 5 minutes for questions, demo recovery, or
+skipped-slide padding. `slides.md` currently contains 23 numbered slides plus
+appendices; slides 1-22 are the prepared talk, and slide 23 is the explicit Q&A
+landing slide.
+
+## Timing Plan
+
+| Segment | Slides | Target |
+|---|---:|---:|
+| Frame the problem | 1-4 | 4 min |
+| Threat map | 5-6 | 3 min |
+| Lab method | 7-9 | 5 min |
+| LLM01 walkthrough | 10-16 | 9 min |
+| Extension, takeaway, and close | 17-19, 21-22; 20 conditional | 4 min |
+| Q&A, appendix, or recovery | 23 and appendices | 5 min |
+
+## Slide Notes
+
+### 1. Title
+
+Open with the core promise: this is not a theoretical AI security survey. It is
+about making risks executable so engineers can test them.
+
+### 2. The Claim
+
+Emphasize that the OWASP Top 10 is useful, but a taxonomy does not prove a
+system is safe. The lab turns the taxonomy into a repeatable engineering loop.
+
+### 3. Why Agents Change The Surface
+
+Make the distinction between a chatbot and an agent. The risk changes when text
+can influence retrieval, tools, memory, scheduled work, or downstream systems.
+
+### 4. The Uncomfortable Idea
+
+Use concrete examples. The attacker may never touch the chat input. They may
+control a log line, a support note, a dependency README, or a document the agent
+retrieves.
+
+### 5. OWASP Top 10 As Threat Map
+
+Move quickly. Do not explain every OWASP category in depth. Reframe each item as
+an engineering question.
+
+### 6. The Rest Of The Map
+
+Use this slide to show breadth, then pivot away from list coverage. Say that the
+audience can read the list later; the talk is about making it executable.
+
+### 7. Why Build A Lab?
+
+Contrast vague claims with measured claims. A defense is more credible when it
+beats the same harness that broke the baseline.
+
+### 8. The Lab Loop
+
+Walk through the loop slowly: target, payloads, harness, result, defense, rerun,
+compare. Stress that changing one variable at a time is what makes the result
+useful.
+
+### 9. Key Lab Components
+
+Tie each component to reproducibility. The writeup matters because future
+engineers need to rerun the experiment, not trust a screenshot.
+
+### 10. Concrete Demo: LLM01
+
+Set context for the demo. The vulnerable RAG assistant retrieves useful
+documents, but one retrieved document can carry hostile instructions.
+
+### 11. The Attack Path
+
+Point out that the user question can be benign. The attack enters through the
+retrieval path.
+
+### 12. What Counts As Success?
+
+Define success before showing results. This prevents the demo from becoming a
+subjective demo assessment.
+
+### 13. Baseline Run
+
+If running live, show the command and result. If using fallback, show captured
+output and explain the fields in the result file.
+
+### 14. Defense Toggle
+
+Explain spotlighting as trust-boundary labeling, not magic. The model still sees
+the content; the prompt structure changes how the model should treat it.
+
+### 15. Defense Run
+
+Stress same payloads, same scoring, same result format. Only the defense
+changes.
+
+### 16. What This Proves
+
+Be careful and credible. The result is evidence, not a universal guarantee.
+This slide is important for the CTO-level audience.
+
+### 17. Extending Across The Top 10
+
+Show that the lab method scales beyond prompt injection. Keep this fast.
+
+### 18. Two High-Value Next Labs
+
+Name supply chain and excessive agency because they connect directly to AI
+coding-agent risk and real engineering decisions.
+
+### 19. Design Review Checklist
+
+This is the practical takeaway. Give the audience questions they can use at work
+the next day.
+
+### 20. Live Demo Or Recorded Walkthrough
+
+Treat this slide as conditional. The default 25-minute prepared path skips the
+live demo; use captured or recorded output only if needed to support the
+walkthrough. Run the live demo only if ahead of schedule, and otherwise say the
+repo contains the runbook and move to the close.
+
+### 21. Roadmap
+
+Mention that the first measured slice exists and the roadmap is to add or deepen
+slices across categories with richer payloads, metadata, writeups, and later the
+interactive lesson workflow.
+
+### 22. Close
+
+End with the method: build small broken agents, attack them honestly, measure
+what changed, and carry the evidence back into real engineering decisions.
+
+### 23. Q&A
+
+Use this as the transition into the reserved 5-minute Q&A and padding window.
+If there are no immediate questions, seed discussion with one of the slide
+prompts and point people toward the appendix material.
+
+## Appendix Notes
+
+### Appendix A. Safety Boundary
+
+Use this only if someone asks about responsible use or whether the lab exercises
+touch real systems. Keep the boundary crisp: local targets, synthetic data, no
+third-party probing.
+
+### Appendix B. Demo Commands
+
+Use this as the fastest recovery path if a command is mistyped or the live demo
+needs to restart from known-good steps. Prefer the full runbook when preparing
+before the talk.
+
+### Appendix C. Full Module Map
+
+Use this for questions about how the method applies beyond prompt injection.
+Point to the module map as the structure for expanding the lab category by
+category.
+
+### Appendix D. Metric Notes
+
+Use this for measurement questions. Reinforce that attack success rate and the
+defense delta are lab signals, not universal claims about all prompt-injection
+payloads.
+
+### Appendix E. References
+
+Use this when people ask where to keep reading. Mention OWASP for taxonomy,
+then the repo roadmap and LLM01 writeup for the executable local path.
+
+## Rehearsal Notes
+
+- If slide 6 ends after minute 7, stay on the default no-live-demo path.
+- If slide 16 ends after minute 21, skip slide 20.
+- Only run the live demo from slide 20 if ahead of schedule; otherwise use
+  captured or recorded output if the walkthrough needs supporting evidence.
+- Keep slide 23 and appendix slides for questions, padding, and recovery.
+- Do not apologize for skipping the live demo; frame it as preserving time for
+  the engineering method.


### PR DESCRIPTION
## Summary

- Adds the repo-native OWASP LLM Top 10 lab presentation package with abstract, outline, slides, speaker notes, demo runbook, and asset/export policies.
- Adds the public Astro talk page at `/talks/summit-owasp-llm-top-10/` for post-presentation viewing without Google Slides.
- Links the package from the root README and updates Giscus maintenance notes.

## Validation

- `git diff --check`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `rg -n 'TBD|TODO|FIXME|\?\?|Planned package artifacts|current delivery artifact is `abstract.md`|Planned delivery artifacts|Add live HTTP attack mode|planned `slides.md`|planned at|/ai_sec_research/talks' talks/summit-owasp-llm-top-10 README.md src/pages/talks/summit-owasp-llm-top-10.astro` returned no matches.
- Local rendered smoke test for `/talks/summit-owasp-llm-top-10`: desktop and mobile, 28 slide sections, no framework overlay, no horizontal overflow.
- `.venv/bin/python lab/attacker/custom/run_v0_rag_attacks.py --mode compare` returned defense-off attack success rate `1.0`, defense-on `0.0`, absolute reduction `1.0`.

## Notes

- Live delivery should use a Google Slides copy created from `talks/summit-owasp-llm-top-10/slides.md` before the June 20 rehearsal target.

Closes #72
