### PR TITLE
[#74] Link Google Slides delivery deck

### DIFF
--- a/talks/summit-owasp-llm-top-10/README.md
+++ b/talks/summit-owasp-llm-top-10/README.md
@@ -31,8 +31,8 @@ Current package artifacts:
 
 ## Viewing Paths
 
-- Live delivery: Google Slides copy created from `slides.md` before the final
-  June 20 rehearsal.
+- Live delivery: Google Slides copy linked from
+  `exports/google-slides-link.md`.
 - Repo-native slide source: `slides.md`.
 - Public web version: `/talks/summit-owasp-llm-top-10/` after deploy.
 

--- a/talks/summit-owasp-llm-top-10/exports/README.md
+++ b/talks/summit-owasp-llm-top-10/exports/README.md
@@ -6,8 +6,8 @@ ready to publish.
 ## Expected Exports
 
 - `slides.pdf` - public PDF export of the final deck.
-- `google-slides-link.md` - link to the live Google Slides delivery copy when
-  it exists.
+- `google-slides-link.md` - verified link to the live Google Slides delivery
+  copy.
 - `llm01-baseline-output.txt` - captured fallback output for the defense-off
   demo.
 - `llm01-defense-output.txt` - captured fallback output for the defense-on demo.

--- a/talks/summit-owasp-llm-top-10/exports/google-slides-link.md
+++ b/talks/summit-owasp-llm-top-10/exports/google-slides-link.md
@@ -1,0 +1,13 @@
+# Google Slides Delivery Copy
+
+Live delivery deck:
+<https://docs.google.com/presentation/d/1RDhrDMg3LogHWyvpNq-a1rYXHvP6MeHXSLfdcWBfDwA/edit?usp=drivesdk>
+
+## Verification
+
+- Imported from the repo-native `slides.md` package on June 2, 2026.
+- Verified as a native Google Slides presentation.
+- Verified title: `Breaking Agents to Build Better Ones - OWASP LLM Top 10 Lab Talk`.
+- Verified slide count: 28.
+- Spot-checked imported large thumbnails for the cover, attack-path, live-demo,
+  and appendix command slides.


### PR DESCRIPTION
## Summary

- Created the live Google Slides delivery copy for the OWASP LLM Top 10 lab talk.
- Added `talks/summit-owasp-llm-top-10/exports/google-slides-link.md` with the verified deck URL and import metadata.
- Updated talk/export docs so the live delivery path points to the verified link file.

## Google Slides Verification

- Deck: `Breaking Agents to Build Better Ones - OWASP LLM Top 10 Lab Talk`
- Native Google Slides ID: `1RDhrDMg3LogHWyvpNq-a1rYXHvP6MeHXSLfdcWBfDwA`
- Slide count: 28
- MIME type from Drive search: `application/vnd.google-apps.presentation`
- Imported thumbnail spot checks: cover, attack-path, live-demo, and appendix command slides.

## Validation

- `git diff --check HEAD~1..HEAD`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- Google Slides connector readback for title, ID, and slide count.

Closes #74
