### PR TITLE
[#80] Prepare OWASP lab talk rehearsal packet

### DIFF
--- a/talks/summit-owasp-llm-top-10/README.md
+++ b/talks/summit-owasp-llm-top-10/README.md
@@ -25,6 +25,7 @@ Current package artifacts:
 - `outline.md` - planning index for the talk package.
 - `slides.md` - repo-native slide source for review and Google Slides mirroring.
 - `speaker-notes.md` - slide-by-slide narration notes and timing.
+- `rehearsal.md` - full-run timing checkpoints, delivery preflight, and run log.
 - `demo-runbook.md` - live demo setup, commands, fallback, and recovery path.
 - `assets/` - local diagrams or images used by the deck, plus asset policy.
 - `exports/slides.pdf` - published 28-page PDF export of the delivery deck.

--- a/talks/summit-owasp-llm-top-10/demo-runbook.md
+++ b/talks/summit-owasp-llm-top-10/demo-runbook.md
@@ -22,10 +22,12 @@ Default path: use the prepared 25-minute talk and captured fallback output in
 
 Live-demo decision point:
 
-- Run the live demo only if slide 20 is reached by minute 18 and there are at
-  least 7 minutes before Q&A.
+- Run the live demo only if slide 16 ends by minute 16:30, slide 20 is reached
+  by minute 18, and there are at least 7 minutes before Q&A.
 - If the live demo runs, cap it at 5 minutes.
 - If the live demo runs long, compress or skip roadmap details before Q&A.
+
+Use `rehearsal.md` for the complete prepared-talk checkpoints and cut order.
 
 Use captured fallback output if:
 

--- a/talks/summit-owasp-llm-top-10/outline.md
+++ b/talks/summit-owasp-llm-top-10/outline.md
@@ -56,12 +56,14 @@ Accepted slot: 30 minutes total.
 
 Prepared talk timing:
 
-- 3 minutes: motivation and framing.
-- 6 minutes: OWASP LLM Top 10 as an engineering map.
-- 9 minutes: live or recorded `LLM01` prompt-injection lab demo.
-- 4 minutes: defenses and measurement.
-- 2 minutes: roadmap across the other OWASP modules.
-- 1 minute: design-review checklist and close.
+- 4 minutes: motivation and framing.
+- 3 minutes: OWASP LLM Top 10 as an engineering map.
+- 5 minutes: lab method and components.
+- 9 minutes: `LLM01` prompt-injection walkthrough and measured defense delta.
+- 4 minutes: extension, design-review checklist, roadmap, and close.
+
+Use `rehearsal.md` for slide checkpoints, cuts, and the conditional live-demo
+decision. Slide 20 is not part of the default 25-minute path.
 
 ## Demo Plan
 

--- a/talks/summit-owasp-llm-top-10/rehearsal.md
+++ b/talks/summit-owasp-llm-top-10/rehearsal.md
@@ -1,0 +1,99 @@
+# Talk Rehearsal
+
+Use this worksheet for full delivery runs before the June 20, 2026 polish
+deadline. The default path is a 25-minute prepared talk without a live demo,
+followed by 5 minutes for questions.
+
+## Delivery Rule
+
+The talk must work without terminal interaction. Use the live demo only when
+slide 20 is reached by minute 18 and the lab is already in a known-good state.
+Otherwise, use the captured result on slides 13-16 and preserve the Q&A window.
+
+## Timing Checkpoints
+
+| Elapsed | Slides | Goal | Cut if behind |
+|---:|---:|---|---|
+| 0:00-4:00 | 1-4 | Frame agent-specific risk and the untrusted-text problem. | Shorten examples on slide 4. |
+| 4:00-7:00 | 5-6 | Present the Top 10 as an engineering map. | Read only the category names and questions. |
+| 7:00-12:00 | 7-9 | Explain the repeatable lab loop and safety boundary. | Compress the component inventory on slide 9. |
+| 12:00-15:00 | 10-12 | Establish the LLM01 target, attack path, and success metric. | Keep only the benign-user-input point on slide 11. |
+| 15:00-21:00 | 13-16 | Compare baseline, defense, rerun, and measured claim. | Show the captured summary fields without narrating each payload. |
+| 21:00-23:00 | 17-19 | Generalize the method and deliver the review checklist. | Skip slide 18 and name the two modules verbally. |
+| 23:00-25:00 | 21-22 | Give the roadmap and close. | Reduce slide 21 to one sentence; do not cut the closing line. |
+| 25:00-30:00 | 23 | Questions, padding, or recovery. | Stop prepared content at minute 25. |
+
+Slide 20 is conditional and is not part of the default timing path.
+
+## Live-Demo Branch
+
+Take this branch only when all conditions are true:
+
+- Slide 16 ends by minute 16:30.
+- Slide 20 is reached by minute 18:00.
+- The comparison command passed during preflight.
+- The terminal is readable from the back of the room.
+- At least 7 minutes remain before the Q&A boundary.
+
+Hard limits:
+
+- Stop the demo after 5 minutes even if a command is still running.
+- Use the captured output after the first environmental failure.
+- Compress slide 21, but keep slide 22 and begin Q&A by minute 25.
+
+## Preflight
+
+### Day Before
+
+- [ ] Open the Google Slides delivery deck and verify presenter access.
+- [ ] Confirm `exports/slides.pdf` opens as the offline deck.
+- [ ] Run the measured comparison from `demo-runbook.md`.
+- [ ] Confirm both captured output files are available locally.
+- [ ] Charge the presentation laptop and pack the required display adapter.
+- [ ] Disable notifications, sleep, and automatic updates for the talk window.
+
+### In The Room
+
+- [ ] Verify the first and last slides fit the projector.
+- [ ] Check that cyan, amber, and body text remain distinguishable.
+- [ ] Test the clicker and presenter-view display arrangement.
+- [ ] Increase terminal font size and hide unrelated windows.
+- [ ] Put the PDF, demo runbook, and captured output in the same local folder.
+- [ ] Start a visible 30-minute timer.
+
+## Full-Run Log
+
+Copy this section for each rehearsal.
+
+```text
+Date:
+Delivery deck version or commit:
+Path: default / live demo
+
+Slide 4 checkpoint:
+Slide 6 checkpoint:
+Slide 9 checkpoint:
+Slide 12 checkpoint:
+Slide 16 checkpoint:
+Slide 19 checkpoint:
+Slide 22 checkpoint:
+Q&A start:
+
+Demo result:
+Words or sections that caused hesitation:
+Slides that felt crowded:
+Audience questions or reviewer feedback:
+Cuts for the next run:
+Keep unchanged:
+```
+
+## Pass Criteria
+
+A full run passes when:
+
+- slide 22 finishes at or before minute 25,
+- the main claim, lab loop, measured result, limitation, and checklist all land,
+- the talk remains coherent when slide 20 is skipped,
+- no recovery step requires network access,
+- Q&A begins with at least 5 minutes remaining.
+

--- a/talks/summit-owasp-llm-top-10/speaker-notes.md
+++ b/talks/summit-owasp-llm-top-10/speaker-notes.md
@@ -3,7 +3,8 @@
 Target: 25 minutes prepared content, 5 minutes for questions, demo recovery, or
 skipped-slide padding. `slides.md` currently contains 23 numbered slides plus
 appendices; slides 1-22 are the prepared talk, and slide 23 is the explicit Q&A
-landing slide.
+landing slide. Use `rehearsal.md` as the source of truth for elapsed-time
+checkpoints and cuts.
 
 ## Timing Plan
 
@@ -171,10 +172,11 @@ then the repo roadmap and LLM01 writeup for the executable local path.
 
 ## Rehearsal Notes
 
-- If slide 6 ends after minute 7, stay on the default no-live-demo path.
-- If slide 16 ends after minute 21, skip slide 20.
-- Only run the live demo from slide 20 if ahead of schedule; otherwise use
-  captured or recorded output if the walkthrough needs supporting evidence.
+- If slide 6 ends after minute 7, use the documented cuts and stay on the
+  default no-live-demo path.
+- The default checkpoint is slide 16 at minute 21, followed by slides 17-19.
+- Only run the live demo if slide 16 ends by minute 16:30 and slide 20 is
+  reached by minute 18. Otherwise use captured output.
 - Keep slide 23 and appendix slides for questions, padding, and recovery.
 - Do not apologize for skipping the live demo; frame it as preserving time for
   the engineering method.


### PR DESCRIPTION
## Summary
- add a full-run rehearsal worksheet with minute-by-minute checkpoints and explicit cuts
- define the conditional live-demo gate, preflight checklist, and reusable run log
- reconcile timing guidance across the outline, speaker notes, and demo runbook

## Verification
- `git diff --check`
- placeholder and timing-gate consistency scan
- offline rehearsal dependency existence check
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`

Closes #80