### PR TITLE
[#89] Add persistent Ops and Direct site views

### DIFF
--- a/docs/superpowers/plans/2026-06-09-small-screens-big-worlds-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-small-screens-big-worlds-implementation.md
@@ -1,0 +1,357 @@
+# Small Screens / Big Worlds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the personal site around the Small Screens / Big Worlds publication identity with an immersive Ops presentation and a persistent, query-addressable Direct presentation.
+
+**Architecture:** Keep one Astro document and one URL for each piece of content. A small inline head script resolves `view` from the query string and local storage, writes `data-view` to the root element before paint, and exposes a header control that switches presentation without duplicating content. Shared components provide the orbital hero, mission navigation, project summaries, editorial taxonomy, and dual-label terminology.
+
+**Tech Stack:** Astro 6, TypeScript in Astro frontmatter and browser scripts, semantic HTML, modern CSS, Node test runner for view-resolution helpers, Astro production build, browser-based responsive and accessibility QA.
+
+---
+
+## File Structure
+
+- `src/lib/view-mode.ts`: pure view parsing and resolution helpers.
+- `scripts/test-view-mode.mjs`: Node assertions for query and preference rules.
+- `src/components/ViewModeToggle.astro`: accessible Ops/Direct switch.
+- `src/components/Header.astro`: publication brand and dual-mode navigation.
+- `src/components/OrbitMap.astro`: decorative and navigational homepage system map.
+- `src/components/MissionCard.astro`: reusable project and article summary.
+- `src/data/site-content.ts`: initial project, capability, and editorial taxonomy.
+- `src/layouts/BaseLayout.astro`: pre-paint mode initialization and updated metadata.
+- `src/styles/global.css`: tokens, shared typography, mode selectors, and accessibility.
+- `src/pages/index.astro`: redesigned publication homepage.
+- `src/pages/projects/index.astro`: Shipyard / Projects index.
+- `src/pages/blog/index.astro`: Flight Log / Blog archive and formats.
+- `src/pages/resume.astro`: mobile-led dual-presentation resume.
+- `src/pages/about.astro`: revised publication and career narrative.
+- `src/content.config.ts`: optional article-format schema additions.
+- `README.md`: updated publication, view-mode, and writing documentation.
+
+### Task 1: Persistent View Infrastructure
+
+**Files:**
+- Create: `src/lib/view-mode.ts`
+- Create: `scripts/test-view-mode.mjs`
+- Create: `src/components/ViewModeToggle.astro`
+- Modify: `src/layouts/BaseLayout.astro`
+- Modify: `src/components/Header.astro`
+- Modify: `src/styles/global.css`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add failing view-resolution assertions**
+
+Create assertions covering valid query values, invalid query values, stored
+preferences, and the Ops default:
+
+```js
+import assert from 'node:assert/strict';
+import {
+  parseViewMode,
+  resolveViewMode,
+} from '../dist-test/view-mode.js';
+
+assert.equal(parseViewMode('direct'), 'direct');
+assert.equal(parseViewMode('ops'), 'ops');
+assert.equal(parseViewMode('other'), null);
+assert.equal(resolveViewMode('direct', 'ops'), 'direct');
+assert.equal(resolveViewMode(null, 'direct'), 'direct');
+assert.equal(resolveViewMode(null, null), 'ops');
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npm run test:view`
+
+Expected: failure because `src/lib/view-mode.ts` and the script do not exist.
+
+- [ ] **Step 3: Implement pure mode helpers**
+
+Implement:
+
+```ts
+export type ViewMode = 'ops' | 'direct';
+
+export function parseViewMode(value: string | null): ViewMode | null {
+  return value === 'ops' || value === 'direct' ? value : null;
+}
+
+export function resolveViewMode(
+  queryMode: string | null,
+  storedMode: string | null,
+): ViewMode {
+  return parseViewMode(queryMode) ?? parseViewMode(storedMode) ?? 'ops';
+}
+```
+
+Compile the helper into a temporary test directory in `test:view`, run the Node
+assertions, and remove the temporary output after the test.
+
+- [ ] **Step 4: Add pre-paint mode resolution**
+
+Add an inline script in `BaseLayout.astro` that:
+
+1. reads `new URLSearchParams(location.search).get('view')`;
+2. accepts only `ops` or `direct`;
+3. falls back to `localStorage.getItem('site-view')`;
+4. defaults to `ops`;
+5. writes `document.documentElement.dataset.view`;
+6. persists a valid query selection;
+7. catches storage failures without blocking rendering.
+
+Keep canonical metadata based on `Astro.url.pathname` so query parameters do not
+create duplicate canonical pages.
+
+- [ ] **Step 5: Add the accessible switch**
+
+Render two real buttons in `ViewModeToggle.astro` within a group labelled
+`Site presentation`. The client script must update `data-view`,
+`aria-pressed`, local storage, and the current URL's `view` parameter using
+`history.replaceState`.
+
+- [ ] **Step 6: Add minimal dual-mode tokens**
+
+Define shared functional colors and `[data-view='direct']` overrides. Ensure the
+page remains legible before scripts execute and under `prefers-reduced-motion`.
+
+- [ ] **Step 7: Verify infrastructure**
+
+Run:
+
+```bash
+npm run test:view
+npm run build
+```
+
+Expected: all assertions pass and Astro completes without errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package.json scripts/test-view-mode.mjs src/lib/view-mode.ts \
+  src/components/ViewModeToggle.astro src/components/Header.astro \
+  src/layouts/BaseLayout.astro src/styles/global.css
+git commit -m "Add persistent Ops and Direct site views"
+```
+
+### Task 2: Publication Shell and Homepage
+
+**Files:**
+- Create: `src/components/OrbitMap.astro`
+- Create: `src/components/MissionCard.astro`
+- Create: `src/data/site-content.ts`
+- Modify: `src/components/Header.astro`
+- Modify: `src/components/Footer.astro`
+- Modify: `src/pages/index.astro`
+- Modify: `src/styles/global.css`
+
+- [ ] **Step 1: Add shared content data**
+
+Define typed records for the four homepage systems:
+
+```ts
+export const systems = [
+  { id: 'mobile', opsLabel: 'Native Mobile', directLabel: 'Mobile Engineering', status: 'Flight proven' },
+  { id: 'react', opsLabel: 'Product Systems', directLabel: 'React and React Native', status: 'Flight proven' },
+  { id: 'games', opsLabel: 'Game Lab', directLabel: 'Game Development', status: 'Under construction' },
+  { id: 'rigor', opsLabel: 'Systems Rigor', directLabel: 'Security and Architecture', status: 'Embedded discipline' },
+] as const;
+```
+
+- [ ] **Step 2: Build the semantic orbital map**
+
+Use an ordinary list of links as the source markup. Apply orbital positioning
+only in Ops mode and at wide breakpoints. In Direct mode and narrow layouts,
+render it as a conventional capability list.
+
+- [ ] **Step 3: Build reusable mission summaries**
+
+`MissionCard.astro` accepts literal and themed labels, title, summary, status,
+and URL. It must not depend on the current mode in JavaScript; CSS selects the
+appropriate visible label.
+
+- [ ] **Step 4: Rebuild the homepage**
+
+Use the approved copy:
+
+```text
+Small Screens / Big Worlds
+Software for small screens and big worlds.
+```
+
+Lead with native mobile and React products. Present game development as a new
+trajectory and AI as part of the toolkit. Include the current experiment,
+selected missions, and latest posts.
+
+- [ ] **Step 5: Verify first-viewport and responsive behavior**
+
+Run the dev server and inspect:
+
+- 1440 x 1000 Ops
+- 1440 x 1000 Direct
+- 390 x 844 Ops
+- 390 x 844 Direct
+
+Expected: publication name, headline, action, and next-section hint remain
+visible; no overlap or horizontal overflow occurs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/OrbitMap.astro src/components/MissionCard.astro \
+  src/data/site-content.ts src/components/Header.astro \
+  src/components/Footer.astro src/pages/index.astro src/styles/global.css
+git commit -m "Rebrand homepage as Small Screens Big Worlds"
+```
+
+### Task 3: Projects and Editorial Taxonomy
+
+**Files:**
+- Create: `src/pages/projects/index.astro`
+- Modify: `src/pages/blog/index.astro`
+- Modify: `src/content.config.ts`
+- Modify: `src/styles/global.css`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add article format metadata**
+
+Extend the blog schema with an optional enum:
+
+```ts
+format: z.enum([
+  'system-deep-dive',
+  'flight-log',
+  'postmortem',
+  'cross-system-test',
+]).optional()
+```
+
+Existing posts must continue building without modification.
+
+- [ ] **Step 2: Build the projects index**
+
+Create sections for Native Mobile, React and React Native, Frontend and Product
+Systems, and Game Lab. Use honest status language and avoid invented client
+outcomes or project metrics.
+
+- [ ] **Step 3: Reframe the blog archive**
+
+Keep existing posts. Add format descriptions and filters that degrade to normal
+links or a complete list without JavaScript. Use `Flight Log / Blog` in Ops and
+`Writing` in Direct.
+
+- [ ] **Step 4: Update author documentation**
+
+Document the four formats, editorial percentages, initial article sequence, and
+frontmatter field in `README.md`.
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: all old blog URLs build and the new projects route appears in output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/projects/index.astro src/pages/blog/index.astro \
+  src/content.config.ts src/styles/global.css README.md
+git commit -m "Add project shipyard and editorial taxonomy"
+```
+
+### Task 4: Resume and About Repositioning
+
+**Files:**
+- Modify: `src/pages/resume.astro`
+- Modify: `src/pages/about.astro`
+- Modify: `src/styles/global.css`
+
+- [ ] **Step 1: Reorder resume positioning**
+
+Lead with mobile engineering, connected products, React/React Native, technical
+leadership, and frontend architecture. Keep factual employment history and
+security achievements. Describe games only as a current learning focus.
+
+- [ ] **Step 2: Implement dual resume presentation**
+
+Ops mode uses Crew File terminology and telemetry framing. Direct mode exposes a
+compact professional heading, capability summary, chronological experience, and
+selected writing without decorative map elements.
+
+- [ ] **Step 3: Rewrite About**
+
+Explain Small Screens / Big Worlds, the move toward game development, practical
+AI use, leadership experience, and security as an embedded discipline.
+
+- [ ] **Step 4: Verify print and narrow layouts**
+
+Check Direct resume at desktop, mobile, and print preview. Expected: readable
+chronology, no clipped content, and no decorative backgrounds consuming ink.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/resume.astro src/pages/about.astro src/styles/global.css
+git commit -m "Reposition resume and about around mobile product work"
+```
+
+### Task 5: Accessibility, Motion, and Final Visual QA
+
+**Files:**
+- Modify: `src/styles/global.css`
+- Modify: affected components from Tasks 1-4
+- Create: `docs/qa/small-screens-big-worlds-qa.md`
+
+- [ ] **Step 1: Run automated production checks**
+
+Run:
+
+```bash
+npm run test:view
+npm run build
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 2: Keyboard-test both modes**
+
+Verify header navigation, view switch, orbital links, project links, blog links,
+and footer links in source order with visible focus.
+
+- [ ] **Step 3: Test reduced motion**
+
+Emulate `prefers-reduced-motion: reduce`. Expected: orbital and status motion
+stops without hiding content or state.
+
+- [ ] **Step 4: Test query-addressable Direct mode**
+
+Open:
+
+```text
+/?view=direct
+/resume?view=direct
+/blog?view=direct
+/projects?view=direct
+```
+
+Expected: each paints Direct mode immediately, persists the preference, and has
+a canonical URL without the query string.
+
+- [ ] **Step 5: Record visual fidelity ledger**
+
+Document concept evidence, browser evidence, mismatches, fixes, desktop/mobile
+viewports, contrast checks, and intentional deviations in
+`docs/qa/small-screens-big-worlds-qa.md`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src docs/qa/small-screens-big-worlds-qa.md
+git commit -m "Complete redesign accessibility and visual QA"
+```
+

--- a/docs/superpowers/specs/2026-06-09-small-screens-big-worlds-design.md
+++ b/docs/superpowers/specs/2026-06-09-small-screens-big-worlds-design.md
@@ -1,0 +1,225 @@
+# Small Screens / Big Worlds Design
+
+## Purpose
+
+Reposition the site from an AI-security publication to a personal technical
+publication led by mobile and product engineering. React and React Native remain
+major supporting disciplines. Game development is presented as an active,
+serious learning trajectory in Godot and Unreal Engine. AI is treated as a
+practical development tool, while security remains visible as an engineering
+quality rather than a separate site identity.
+
+The summit presentation work is paused and does not appear in the redesigned
+homepage narrative.
+
+## Brand
+
+The primary publication identity is **Small Screens / Big Worlds**.
+
+Shawn Campbell remains explicit in the header, metadata, resume, and author
+information. The site is not presented as a fictional company or anonymous
+studio.
+
+The retained homepage headline is:
+
+> Software for small screens and big worlds.
+
+Supporting copy describes native mobile systems, React products, game
+development, AI-assisted workflows, and engineering leadership without
+overstating current game-development experience.
+
+## Audience Priority
+
+1. Engineers and technical peers
+2. Hiring managers and recruiters
+3. Conference and blog readers
+
+Mobile and product engineering lead the first viewport. Game development is
+clearly identified as a growing body of work. Security appears as systems rigor
+inside case studies, articles, and resume content.
+
+## Visual Direction
+
+The default presentation is an immersive, playful, hard-science-fiction
+operations interface:
+
+- dark shipboard surfaces;
+- cyan, amber, coral, and green functional accents;
+- orbital navigation and mission-board compositions;
+- condensed display typography paired with readable sans-serif body text;
+- monospaced interface labels;
+- sharp or lightly rounded industrial geometry;
+- playful status language, easter eggs, and system feedback;
+- real project screenshots and playable artifacts as the main visual evidence.
+
+The design is inspired by utilitarian spacecraft interfaces without copying
+franchise logos, characters, names, or exact screen designs.
+
+Decorative telemetry must not replace meaningful project content. Scanlines,
+noise, and animation cannot run over body text.
+
+## View Modes
+
+The site has two presentations of the same semantic content.
+
+### Ops
+
+`Ops` is the default presentation. It uses immersive layouts and playful
+shipboard terminology:
+
+- Shipyard / Projects
+- Flight Log / Blog
+- Crew File / Resume
+- Mission Map / Home
+
+Every themed label includes a literal companion in accessible text or nearby
+copy.
+
+### Direct
+
+`Direct` presents conventional navigation, compact typography, scannable
+project summaries, standard resume language, and reduced decorative UI. It is
+intended for recruiters, hiring managers, and readers who want immediate access
+to evidence.
+
+Direct mode is not a separate site. Both modes use identical URLs, source
+content, document semantics, metadata, and functionality.
+
+### Selection Contract
+
+View resolution order:
+
+1. `?view=direct` or `?view=ops`
+2. a saved local preference
+3. `Ops`
+
+A valid query parameter updates the saved preference. The header switch updates
+the saved preference and current document without changing the content URL.
+Invalid query values are ignored.
+
+Examples:
+
+- `https://sandkcampbell.com/?view=direct`
+- `https://sandkcampbell.com/resume?view=direct`
+- `https://sandkcampbell.com/blog/example?view=direct`
+
+Canonical URLs omit the query parameter. An inline head script resolves the mode
+before first paint to avoid a flash of the wrong presentation. The page remains
+usable when JavaScript or local storage is unavailable.
+
+## Information Architecture
+
+### Home
+
+- publication identity and retained headline;
+- mobile/product positioning;
+- orbital map of native mobile, React products, game development, and systems
+  rigor;
+- selected project missions;
+- current game-development experiment;
+- latest writing;
+- direct-mode shortcut.
+
+### Projects
+
+The Shipyard / Projects page groups work into:
+
+- Native Mobile
+- React and React Native
+- Frontend and Product Systems
+- Game Lab
+
+Each case study should show role, constraints, decisions, implementation,
+outcome, screenshots or playable evidence, and lessons learned. Game projects
+must clearly distinguish completed experience from active learning.
+
+### Blog
+
+The Flight Log / Blog supports four formats:
+
+- System Deep Dives
+- Flight Logs
+- Postmortems
+- Cross-System Tests
+
+Editorial emphasis:
+
+- 50% mobile and product engineering;
+- 20% AI-assisted development;
+- 20% game-development field logs;
+- 10% security and systems rigor.
+
+Existing security articles remain in the main archive and are categorized as
+systems-under-stress material.
+
+### Resume
+
+The Crew File / Resume prioritizes:
+
+- mobile and connected-product engineering;
+- React and React Native leadership;
+- frontend architecture;
+- technical leadership and team building;
+- security as an embedded engineering discipline;
+- game development as a current learning focus, not established expertise.
+
+Direct mode must read as a conventional professional resume suitable for a job
+application link.
+
+### About
+
+The About page explains the publication, Shawn's engineering background, the
+current game-development trajectory, and the role of AI in the development
+workflow.
+
+## Initial Editorial Backlog
+
+Recommended first publication sequence:
+
+1. Building the Same Feature in SwiftUI, Jetpack Compose, and React Native
+2. What AI Coding Agents Get Wrong About Mobile Apps
+3. Learning Godot as a Mobile Systems Engineer
+4. Offline-First Sync Without Lying to the User
+
+Additional topics:
+
+- Cross-Platform Without Lowest-Common-Denominator Design
+- The Mobile App Lifecycle Is Part of Your Architecture
+- Building My First Complete Gameplay Loop in Godot
+- The Same Mechanic in Godot and Unreal
+- What Product Engineers Have to Unlearn When Building Games
+- Using AI for Game Prototypes Without Surrendering Art Direction
+- Can an AI Agent Build a Feature That Survives Real Device Testing?
+- Security Is Product Quality: Permissions, Storage, and Trust
+
+## Accessibility
+
+- Meet WCAG AA contrast requirements in both modes.
+- Respect `prefers-reduced-motion`.
+- Maintain a clear visible focus state.
+- Make orbital navigation keyboard accessible.
+- Provide conventional link alternatives to all spatial navigation.
+- Never use color as the only state indicator.
+- Keep body copy free from scanlines and moving visual effects.
+- Preserve semantic heading order and landmarks in both modes.
+- Ensure the view switch has an accessible name and selected-state semantics.
+- Keep content available if JavaScript, storage, or animation is unavailable.
+
+## Responsive Behavior
+
+The first viewport must preserve the publication name, headline, primary action,
+and a hint of the next section on desktop and mobile. Orbital content collapses
+into a stable vertical mission list on narrow screens. Navigation remains
+conventional enough to operate without understanding the theme.
+
+## Success Criteria
+
+- A recruiter can open any page with `?view=direct` and immediately understand
+  Shawn's experience and current focus.
+- A technical reader sees mobile authority before game-development ambition.
+- Ops mode is memorable, playful, and substantially more immersive than the
+  current site.
+- Existing security posts and research remain reachable and credible.
+- Both modes pass keyboard, responsive, reduced-motion, and contrast checks.
+- The production build contains no duplicate mode-specific content pages.
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "test:view": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/test-view-mode.mjs",
     "test:lab": "node scripts/run-lab-tests.mjs"
   },
   "dependencies": {

--- a/scripts/test-view-mode.mjs
+++ b/scripts/test-view-mode.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+
+import {
+  parseViewMode,
+  resolveViewMode,
+} from '../src/lib/view-mode.ts';
+
+assert.equal(parseViewMode('direct'), 'direct');
+assert.equal(parseViewMode('ops'), 'ops');
+assert.equal(parseViewMode('DIRECT'), null);
+assert.equal(parseViewMode('other'), null);
+assert.equal(parseViewMode(null), null);
+
+assert.equal(resolveViewMode('direct', 'ops'), 'direct');
+assert.equal(resolveViewMode('ops', 'direct'), 'ops');
+assert.equal(resolveViewMode('invalid', 'direct'), 'direct');
+assert.equal(resolveViewMode(null, 'direct'), 'direct');
+assert.equal(resolveViewMode(null, 'invalid'), 'ops');
+assert.equal(resolveViewMode(null, null), 'ops');
+
+console.log('view-mode tests passed');

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import ViewModeToggle from './ViewModeToggle.astro';
+
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const links = [
   { href: `${base}/`, label: 'Home' },
@@ -11,16 +13,19 @@ const links = [
 <header>
   <nav>
     <a href={`${base}/`} class="brand">ai-sec-research</a>
-    <ul>
-      {links.map((l) => <li><a href={l.href}>{l.label}</a></li>)}
-    </ul>
+    <div class="nav-actions">
+      <ul>
+        {links.map((l) => <li><a href={l.href}>{l.label}</a></li>)}
+      </ul>
+      <ViewModeToggle />
+    </div>
   </nav>
 </header>
 
 <style>
   header {
     border-bottom: 1px solid var(--border);
-    background: rgba(5, 10, 17, 0.72);
+    background: var(--header-bg);
     backdrop-filter: blur(14px);
   }
 
@@ -50,6 +55,13 @@ const links = [
     gap: 0.35rem 0.9rem;
   }
 
+  .nav-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1rem;
+  }
+
   a {
     color: var(--link);
     text-decoration: none;
@@ -68,8 +80,21 @@ const links = [
       flex-direction: column;
     }
 
+    .nav-actions {
+      width: 100%;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+
     ul {
       justify-content: flex-start;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .nav-actions {
+      flex-direction: column;
     }
   }
 </style>

--- a/src/components/ViewModeToggle.astro
+++ b/src/components/ViewModeToggle.astro
@@ -1,0 +1,83 @@
+<div class="view-mode" role="group" aria-label="Site presentation">
+  <button type="button" data-view-choice="ops" aria-pressed="true">
+    Ops
+  </button>
+  <button type="button" data-view-choice="direct" aria-pressed="false">
+    Direct
+  </button>
+</div>
+
+<script>
+  const storageKey = 'site-view';
+  const buttons = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-view-choice]'),
+  );
+
+  function isViewMode(value: string | undefined): value is 'ops' | 'direct' {
+    return value === 'ops' || value === 'direct';
+  }
+
+  function applyViewMode(mode: 'ops' | 'direct', updateUrl: boolean) {
+    document.documentElement.dataset.view = mode;
+
+    for (const button of buttons) {
+      button.setAttribute(
+        'aria-pressed',
+        String(button.dataset.viewChoice === mode),
+      );
+    }
+
+    try {
+      localStorage.setItem(storageKey, mode);
+    } catch {
+      // Storage can be unavailable in privacy-focused browser contexts.
+    }
+
+    if (updateUrl) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('view', mode);
+      history.replaceState(history.state, '', url);
+    }
+  }
+
+  const initialMode = document.documentElement.dataset.view;
+  applyViewMode(isViewMode(initialMode) ? initialMode : 'ops', false);
+
+  for (const button of buttons) {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.viewChoice;
+      if (isViewMode(mode)) {
+        applyViewMode(mode, true);
+      }
+    });
+  }
+</script>
+
+<style>
+  .view-mode {
+    display: inline-grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    border: 1px solid var(--border);
+    padding: 0.2rem;
+  }
+
+  button {
+    min-width: 4.25rem;
+    border: 0;
+    background: transparent;
+    color: var(--fg-muted);
+    cursor: pointer;
+    font: 700 0.72rem/1 var(--font-mono);
+    padding: 0.55rem 0.65rem;
+    text-transform: uppercase;
+  }
+
+  button[aria-pressed='true'] {
+    background: var(--accent);
+    color: var(--control-active-fg);
+  }
+
+  button:hover {
+    color: var(--fg);
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,11 +13,41 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-view="ops">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
+    <script is:inline>
+      (() => {
+        const storageKey = 'site-view';
+        const queryMode = new URLSearchParams(window.location.search).get('view');
+        const isMode = (value) => value === 'ops' || value === 'direct';
+        let storedMode = null;
+
+        try {
+          storedMode = localStorage.getItem(storageKey);
+        } catch {
+          // Storage can be unavailable in privacy-focused browser contexts.
+        }
+
+        const mode = isMode(queryMode)
+          ? queryMode
+          : isMode(storedMode)
+            ? storedMode
+            : 'ops';
+
+        document.documentElement.dataset.view = mode;
+
+        if (isMode(queryMode)) {
+          try {
+            localStorage.setItem(storageKey, mode);
+          } catch {
+            // The selected mode still applies for the current page.
+          }
+        }
+      })();
+    </script>
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonical} />

--- a/src/lib/view-mode.ts
+++ b/src/lib/view-mode.ts
@@ -1,0 +1,12 @@
+export type ViewMode = 'ops' | 'direct';
+
+export function parseViewMode(value: string | null): ViewMode | null {
+  return value === 'ops' || value === 'direct' ? value : null;
+}
+
+export function resolveViewMode(
+  queryMode: string | null,
+  storedMode: string | null,
+): ViewMode {
+  return parseViewMode(queryMode) ?? parseViewMode(storedMode) ?? 'ops';
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,9 +22,37 @@
   --link-hover: #ffd88f;
   --focus: #ffd88f;
   --code-bg: rgba(5, 10, 17, 0.86);
+  --header-bg: rgba(5, 10, 17, 0.72);
+  --control-active-fg: #07111b;
   --shell-width: 1080px;
   --article-width: 760px;
   --panel-shadow: 0 20px 70px rgba(0, 0, 0, 0.26);
+}
+
+html[data-view='direct'] {
+  color-scheme: light;
+
+  --bg: #f1f5f4;
+  --bg-deep: #e6ecea;
+  --bg-panel: rgba(255, 255, 255, 0.92);
+  --bg-panel-strong: #ffffff;
+  --bg-subtle: rgba(22, 101, 107, 0.08);
+  --fg: #142126;
+  --fg-muted: #4d6269;
+  --fg-subtle: #647a81;
+  --border: rgba(28, 91, 97, 0.28);
+  --border-strong: rgba(28, 91, 97, 0.58);
+  --accent: #2d858b;
+  --accent-strong: #176a70;
+  --warning: #9a6515;
+  --warning-strong: #744806;
+  --link: #176a70;
+  --link-hover: #744806;
+  --focus: #9a6515;
+  --code-bg: #e7eeec;
+  --header-bg: rgba(244, 248, 247, 0.9);
+  --control-active-fg: #ffffff;
+  --panel-shadow: 0 14px 45px rgba(24, 50, 54, 0.12);
 }
 
 * {
@@ -50,6 +78,14 @@ body {
   color: var(--fg);
   font-size: 17px;
   line-height: 1.65;
+}
+
+html[data-view='direct'] body {
+  background:
+    linear-gradient(rgba(28, 91, 97, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(28, 91, 97, 0.045) 1px, transparent 1px),
+    var(--bg);
+  background-size: 48px 48px;
 }
 
 main {
@@ -190,6 +226,11 @@ img {
   box-shadow: var(--panel-shadow);
 }
 
+html[data-view='direct'] .panel,
+html[data-view='direct'] .signal-card {
+  background: var(--bg-panel);
+}
+
 .kicker {
   margin: 0 0 0.65rem;
   color: var(--warning);
@@ -256,5 +297,16 @@ img {
   main {
     width: min(100% - 1rem, var(--shell-width));
     padding-top: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary

- document the approved Small Screens / Big Worlds redesign and implementation sequence
- add persistent Ops and Direct presentation modes with `?view=` deep links
- add an accessible header switch, pre-paint mode resolution, Direct tokens, and reduced-motion defaults
- add focused tests for query, preference, invalid-value, and default precedence

## Behavior

View resolution follows:

1. `?view=direct` or `?view=ops`
2. saved `site-view` preference
3. Ops default

Valid query selections and toggle changes persist locally. Canonical URLs omit
the query parameter, and the site remains usable in Ops mode without JavaScript.

## Validation

- `npm run test:view`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- rendered checks for query selection, toggle state, URL synchronization,
  persistence across navigation, invalid query fallback, and canonical URLs

Closes #89
Part of #86
