### PR TITLE
[#90] Build Small Screens / Big Worlds shell and homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "test:view": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/test-view-mode.mjs",
+    "test:shell": "node scripts/test-publication-shell.mjs",
     "test:lab": "node scripts/run-lab-tests.mjs"
   },
   "dependencies": {

--- a/scripts/test-publication-shell.mjs
+++ b/scripts/test-publication-shell.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [header, homepage, orbitMap, content] = await Promise.all([
+  readFile(new URL('../src/components/Header.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/pages/index.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/components/OrbitMap.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/data/site-content.ts', import.meta.url), 'utf8'),
+]);
+
+assert.match(header, /Small Screens/);
+assert.match(header, /Shawn Campbell/);
+assert.match(homepage, /Software for/);
+assert.match(homepage, /small screens/);
+assert.match(homepage, /big worlds/);
+assert.match(homepage, /OrbitMap/);
+assert.match(homepage, /MissionCard/);
+assert.match(orbitMap, /<ul/);
+assert.match(orbitMap, /href=/);
+assert.match(content, /Flight proven/);
+assert.match(content, /Under construction/);
+assert.match(content, /Security and Architecture/);
+
+console.log('publication shell tests passed');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@ const year = new Date().getFullYear();
 
 <footer>
   <p>
-    © {year} Shawn Campbell ·
+    © {year} Shawn Campbell · Small Screens / Big Worlds ·
     <a href="https://github.com/jaegerpicker/ai_sec_research">source</a> ·
     <a href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/rss.xml`}>rss</a>
   </p>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,6 +4,7 @@ import ViewModeToggle from './ViewModeToggle.astro';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const links = [
   { href: `${base}/`, label: 'Home' },
+  { href: `${base}/#selected-work`, label: 'Projects', opsLabel: 'Shipyard' },
   { href: `${base}/blog`, label: 'Blog' },
   { href: `${base}/resume`, label: 'Resume' },
   { href: `${base}/about`, label: 'About' },
@@ -12,10 +13,23 @@ const links = [
 
 <header>
   <nav>
-    <a href={`${base}/`} class="brand">ai-sec-research</a>
+    <a href={`${base}/`} class="brand">
+      <span class="brand-mark" aria-hidden="true"></span>
+      <span>
+        <strong>Small Screens / Big Worlds</strong>
+        <small>by Shawn Campbell</small>
+      </span>
+    </a>
     <div class="nav-actions">
       <ul>
-        {links.map((l) => <li><a href={l.href}>{l.label}</a></li>)}
+        {links.map((l) => (
+          <li>
+            <a href={l.href}>
+              {l.opsLabel && <span class="ops-only">{l.opsLabel}</span>}
+              <span class={l.opsLabel ? 'direct-only' : undefined}>{l.label}</span>
+            </a>
+          </li>
+        ))}
       </ul>
       <ViewModeToggle />
     </div>
@@ -40,9 +54,39 @@ const links = [
   }
 
   .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
     color: var(--fg);
     font-family: var(--font-mono);
     font-weight: 700;
+  }
+
+  .brand-mark {
+    width: 1.85rem;
+    aspect-ratio: 1;
+    border: 1px solid var(--warning);
+    border-radius: 50%;
+    background:
+      linear-gradient(var(--warning), var(--warning)) center / 140% 1px no-repeat,
+      linear-gradient(var(--warning), var(--warning)) center / 1px 140% no-repeat;
+  }
+
+  .brand strong,
+  .brand small {
+    display: block;
+  }
+
+  .brand strong {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+  }
+
+  .brand small {
+    margin-top: 0.15rem;
+    color: var(--fg-muted);
+    font-size: 0.64rem;
+    font-weight: 500;
   }
 
   ul {

--- a/src/components/MissionCard.astro
+++ b/src/components/MissionCard.astro
@@ -1,0 +1,103 @@
+---
+interface Props {
+  label: string;
+  directLabel: string;
+  title: string;
+  summary: string;
+  status: string;
+  href: string;
+  tone?: 'cyan' | 'amber' | 'green';
+}
+
+const {
+  label,
+  directLabel,
+  title,
+  summary,
+  status,
+  href,
+  tone = 'cyan',
+} = Astro.props;
+---
+
+<a class={`mission-card mission-card--${tone}`} href={href}>
+  <span class="mission-card__label">
+    <span class="ops-only">{label}</span>
+    <span class="direct-only">{directLabel}</span>
+  </span>
+  <strong>{title}</strong>
+  <p>{summary}</p>
+  <small>{status}</small>
+</a>
+
+<style>
+  .mission-card {
+    display: grid;
+    align-content: start;
+    gap: 0.65rem;
+    min-height: 15rem;
+    border-top: 2px solid var(--accent);
+    border-right: 1px solid var(--border);
+    background: var(--bg-panel);
+    color: var(--fg);
+    padding: 1.25rem;
+    text-decoration: none;
+  }
+
+  .mission-card--amber {
+    border-top-color: var(--warning);
+  }
+
+  .mission-card--green {
+    border-top-color: #a9d46e;
+  }
+
+  .mission-card:hover,
+  .mission-card:focus-visible {
+    background: var(--bg-panel-strong);
+    color: var(--fg);
+    text-decoration: none;
+  }
+
+  .mission-card__label,
+  small {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .mission-card__label {
+    color: var(--accent-strong);
+  }
+
+  .mission-card--amber .mission-card__label {
+    color: var(--warning-strong);
+  }
+
+  .mission-card--green .mission-card__label {
+    color: #a9d46e;
+  }
+
+  strong {
+    font-size: 1.08rem;
+    line-height: 1.3;
+  }
+
+  p {
+    color: var(--fg-muted);
+    font-size: 0.92rem;
+    line-height: 1.55;
+  }
+
+  small {
+    align-self: end;
+    color: var(--fg-subtle);
+  }
+
+  :global(html[data-view='direct']) .mission-card {
+    min-height: 0;
+    border: 1px solid var(--border);
+    border-top: 3px solid var(--accent);
+  }
+</style>

--- a/src/components/OrbitMap.astro
+++ b/src/components/OrbitMap.astro
@@ -1,0 +1,206 @@
+---
+import { systems } from '../data/site-content';
+---
+
+<nav class="orbit-map" aria-label="Engineering focus areas">
+  <div class="orbit-map__visual" aria-hidden="true">
+    <span class="orbit orbit--outer"></span>
+    <span class="orbit orbit--middle"></span>
+    <span class="orbit orbit--inner"></span>
+    <span class="orbit-map__axis orbit-map__axis--x"></span>
+    <span class="orbit-map__axis orbit-map__axis--y"></span>
+    <span class="orbit-map__core"></span>
+  </div>
+
+  <ul>
+    {systems.map((system, index) => (
+      <li class={`orbit-node orbit-node--${index + 1}`}>
+        <a href={system.href}>
+          <span class="ops-only">{system.opsLabel}</span>
+          <span class="direct-only">{system.directLabel}</span>
+          <small>{system.status}</small>
+        </a>
+      </li>
+    ))}
+  </ul>
+</nav>
+
+<style>
+  .orbit-map {
+    min-height: 31rem;
+    position: relative;
+  }
+
+  .orbit-map__visual {
+    position: absolute;
+    inset: 0;
+  }
+
+  .orbit {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .orbit--outer {
+    width: min(28rem, 86%);
+    aspect-ratio: 1;
+  }
+
+  .orbit--middle {
+    width: min(19rem, 60%);
+    aspect-ratio: 1;
+    border-color: rgba(228, 173, 84, 0.28);
+  }
+
+  .orbit--inner {
+    width: 7rem;
+    aspect-ratio: 1;
+    border-color: var(--warning);
+  }
+
+  .orbit-map__axis {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    background: rgba(228, 173, 84, 0.62);
+    transform: translate(-50%, -50%);
+  }
+
+  .orbit-map__axis--x {
+    width: 10rem;
+    height: 1px;
+  }
+
+  .orbit-map__axis--y {
+    width: 1px;
+    height: 10rem;
+  }
+
+  .orbit-map__core {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 50%;
+    background: var(--warning-strong);
+    box-shadow: 0 0 1.75rem rgba(228, 173, 84, 0.8);
+    transform: translate(-50%, -50%);
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .orbit-node {
+    position: absolute;
+    z-index: 1;
+  }
+
+  .orbit-node--1 {
+    top: 10%;
+    right: 3%;
+  }
+
+  .orbit-node--2 {
+    top: 39%;
+    left: 2%;
+  }
+
+  .orbit-node--3 {
+    right: 5%;
+    bottom: 10%;
+  }
+
+  .orbit-node--4 {
+    left: 8%;
+    bottom: 8%;
+  }
+
+  a {
+    display: grid;
+    gap: 0.25rem;
+    min-width: 10.5rem;
+    border: 1px solid var(--border);
+    background: rgba(5, 10, 17, 0.9);
+    color: var(--fg);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.65rem 0.75rem;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  a:hover,
+  a:focus-visible {
+    border-color: var(--border-strong);
+    color: var(--warning-strong);
+    text-decoration: none;
+  }
+
+  small {
+    color: var(--fg-muted);
+    font-size: 0.61rem;
+  }
+
+  :global(html[data-view='direct']) .orbit-map {
+    min-height: 0;
+  }
+
+  :global(html[data-view='direct']) .orbit-map__visual {
+    display: none;
+  }
+
+  :global(html[data-view='direct']) ul {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  :global(html[data-view='direct']) .orbit-node {
+    position: static;
+  }
+
+  :global(html[data-view='direct']) a {
+    min-height: 100%;
+    background: var(--bg-panel);
+    color: var(--fg);
+    font-family: var(--font-sans);
+    font-size: 0.88rem;
+    text-transform: none;
+  }
+
+  @media (max-width: 760px) {
+    .orbit-map,
+    :global(html[data-view='ops']) .orbit-map {
+      min-height: 0;
+    }
+
+    .orbit-map__visual {
+      display: none;
+    }
+
+    ul,
+    :global(html[data-view='direct']) ul {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.65rem;
+    }
+
+    .orbit-node {
+      position: static;
+    }
+
+    a {
+      min-width: 0;
+      background: var(--bg-panel);
+    }
+  }
+</style>

--- a/src/data/site-content.ts
+++ b/src/data/site-content.ts
@@ -1,0 +1,67 @@
+export const systems = [
+  {
+    id: 'mobile',
+    opsLabel: 'Native Mobile',
+    directLabel: 'Mobile Engineering',
+    detail: 'Swift, Kotlin, connected devices, and resilient field workflows.',
+    status: 'Flight proven',
+    href: '#selected-work',
+  },
+  {
+    id: 'react',
+    opsLabel: 'Product Systems',
+    directLabel: 'React and React Native',
+    detail: 'Cross-platform products, frontend architecture, and design systems.',
+    status: 'Flight proven',
+    href: '#selected-work',
+  },
+  {
+    id: 'games',
+    opsLabel: 'Game Lab',
+    directLabel: 'Game Development',
+    detail: 'Godot and Unreal experiments, mechanics, tools, and postmortems.',
+    status: 'Under construction',
+    href: '#game-lab',
+  },
+  {
+    id: 'rigor',
+    opsLabel: 'Systems Rigor',
+    directLabel: 'Security and Architecture',
+    detail: 'Threat-aware engineering, distributed systems, and technical leadership.',
+    status: 'Embedded discipline',
+    href: '#systems-rigor',
+  },
+] as const;
+
+export const missions = [
+  {
+    label: '01 / Mobile',
+    directLabel: 'Mobile Engineering',
+    title: 'Native systems for the real world',
+    summary:
+      'Long-running work across iOS, Android, connected devices, offline behavior, and operationally demanding products.',
+    status: 'Flight proven',
+    href: '/resume',
+    tone: 'cyan',
+  },
+  {
+    label: '02 / Product',
+    directLabel: 'React and React Native',
+    title: 'Cross-platform product systems',
+    summary:
+      'Frontend architecture, GraphQL, design systems, performance, and team-scale delivery without flattening platform strengths.',
+    status: 'Flight proven',
+    href: '/resume',
+    tone: 'amber',
+  },
+  {
+    label: '03 / Frontier',
+    directLabel: 'Game Development',
+    title: 'Playable experiments and honest field notes',
+    summary:
+      'A visible learning trajectory through Godot and Unreal, focused on mechanics, game state, tools, and AI-assisted iteration.',
+    status: 'Under construction',
+    href: '/blog',
+    tone: 'green',
+  },
+] as const;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,7 +8,10 @@ interface Props {
   description?: string;
 }
 
-const { title, description = 'Notes on AI security, red teaming, and agent attack surface.' } = Astro.props;
+const {
+  title,
+  description = 'Mobile engineering, product systems, AI-assisted development, and game-development field notes by Shawn Campbell.',
+} = Astro.props;
 const canonical = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
@@ -58,7 +61,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
     <link
       rel="alternate"
       type="application/rss+xml"
-      title="ai-sec-research"
+      title="Small Screens / Big Worlds"
       href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/rss.xml`}
     />
   </head>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import MissionCard from '../components/MissionCard.astro';
+import OrbitMap from '../components/OrbitMap.astro';
+import { missions } from '../data/site-content';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const posts = (await getCollection('blog', ({ data }) => !data.draft))
@@ -8,24 +11,80 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   .slice(0, 5);
 ---
 
-<BaseLayout title="ai-sec-research">
-  <section class="home-hero panel">
-    <p class="kicker">AI Security Research / Field Notes</p>
-    <h1>ai-sec-research</h1>
-    <p class="mission-copy">
-      Notes on AI security, red teaming, and the attack surface of agentic systems.
-      Maintained by Shawn Campbell. Written to think clearly about what breaks,
-      what defends, and what evidence survives contact with real systems.
+<BaseLayout
+  title="Small Screens / Big Worlds — Shawn Campbell"
+  description="Native mobile systems, React products, AI-assisted development, and a growing body of work in games."
+>
+  <section class="home-hero">
+    <div class="hero-copy">
+      <p class="kicker ops-only">Build status / curious and operational</p>
+      <p class="kicker direct-only">Mobile and Product Engineering</p>
+      <h1>Software for <span>small screens</span> and big worlds.</h1>
+      <p class="mission-copy">
+        I build native mobile systems, React products, and increasingly, games.
+        AI is part of the toolkit: useful for accelerating experiments, never a
+        substitute for engineering judgment.
+      </p>
+      <div class="hero-actions">
+        <a class="primary-action" href="#selected-work">
+          <span class="ops-only">Enter the shipyard</span>
+          <span class="direct-only">View selected work</span>
+        </a>
+        <a href={`${base}/blog`}>
+          <span class="ops-only">Open the flight log</span>
+          <span class="direct-only">Read the blog</span>
+        </a>
+      </div>
+    </div>
+    <OrbitMap />
+  </section>
+
+  <section class="mission-board" id="selected-work" aria-labelledby="work-heading">
+    <header>
+      <p class="kicker ops-only">Active Mission Board</p>
+      <p class="kicker direct-only">Selected Work</p>
+      <h2 id="work-heading">
+        <span class="ops-only">Systems worth opening up</span>
+        <span class="direct-only">Mobile, product, and game-development work</span>
+      </h2>
+      <p>
+        Real engineering decisions, constraints, implementation details, and
+        lessons learned.
+      </p>
+    </header>
+    <div class="mission-grid">
+      {missions.map((mission) => <MissionCard {...mission} />)}
+    </div>
+  </section>
+
+  <section class="current-course" id="game-lab" aria-labelledby="course-heading">
+    <div>
+      <p class="kicker ops-only">Current Trajectory</p>
+      <p class="kicker direct-only">Current Focus</p>
+      <h2 id="course-heading">Learning game development in public</h2>
+    </div>
+    <p>
+      I am bringing decades of mobile, frontend, architecture, and team
+      leadership experience into Godot and Unreal. The goal is playable work,
+      clear postmortems, and an honest record of what transfers and what does not.
     </p>
-    <p class="hero-link">
-      <a href={`${base}/blog`}>Read the blog</a>
+  </section>
+
+  <section class="systems-rigor" id="systems-rigor">
+    <p class="kicker ops-only">Hull Integrity</p>
+    <p class="kicker direct-only">Engineering Discipline</p>
+    <h2>Security remains part of product quality.</h2>
+    <p>
+      Threat modeling, permissions, storage, trust boundaries, and failure modes
+      stay inside the engineering story rather than becoming a separate identity.
     </p>
   </section>
 
   {posts.length > 0 && (
     <section class="latest-section" aria-labelledby="latest-heading">
-      <p class="kicker">Latest Signals</p>
-      <h2 id="latest-heading">Recent Notes</h2>
+      <p class="kicker ops-only">Latest Transmissions</p>
+      <p class="kicker direct-only">Latest Writing</p>
+      <h2 id="latest-heading">Dispatches from the build</h2>
       <div class="post-grid">
         {posts.map((post) => (
           <a class="signal-card" href={`${base}/blog/${post.id}`}>
@@ -41,25 +100,110 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
 <style>
   .home-hero {
-    padding: clamp(1.25rem, 4vw, 2.5rem);
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(24rem, 0.9fr);
+    min-height: min(39rem, calc(100vh - 8rem));
+    border-bottom: 1px solid var(--border);
+    background:
+      linear-gradient(rgba(94, 218, 231, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(94, 218, 231, 0.035) 1px, transparent 1px);
+    background-size: 44px 44px;
+  }
+
+  .hero-copy {
+    align-self: center;
+    padding: clamp(2.5rem, 7vw, 5rem) clamp(1.25rem, 5vw, 4.5rem);
   }
 
   .home-hero h1 {
     margin: 0;
+    max-width: 52rem;
+    font-size: clamp(3.2rem, 6vw, 5.65rem);
+    line-height: 0.9;
+    text-transform: uppercase;
+  }
+
+  .home-hero h1 span {
+    color: var(--warning-strong);
   }
 
   .mission-copy {
-    max-width: 48rem;
+    max-width: 44rem;
     color: var(--fg-muted);
     font-size: clamp(1.05rem, 2vw, 1.25rem);
   }
 
-  .hero-link {
-    margin-bottom: 0;
+  .hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .hero-actions a {
+    border: 1px solid var(--border-strong);
+    color: var(--fg);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.7rem 0.85rem;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .hero-actions .primary-action {
+    border-color: var(--warning);
+    background: var(--warning);
+    color: var(--control-active-fg);
+  }
+
+  .mission-board {
+    display: grid;
+    grid-template-columns: minmax(17rem, 0.8fr) minmax(0, 2.2fr);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .mission-board > header {
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+    border-right: 1px solid var(--border);
+  }
+
+  .mission-board h2,
+  .current-course h2,
+  .systems-rigor h2 {
+    margin-top: 0;
+  }
+
+  .mission-board header > p:last-child,
+  .current-course > p,
+  .systems-rigor > p:last-child {
+    color: var(--fg-muted);
+  }
+
+  .mission-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .current-course,
+  .systems-rigor {
+    display: grid;
+    grid-template-columns: minmax(16rem, 0.85fr) minmax(0, 1.5fr);
+    gap: clamp(1.5rem, 5vw, 4rem);
+    padding: clamp(2rem, 5vw, 4rem);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .current-course {
+    background: rgba(169, 212, 110, 0.045);
+  }
+
+  .systems-rigor {
+    background: rgba(238, 119, 99, 0.04);
   }
 
   .latest-section {
-    margin-top: 1.25rem;
+    padding-top: 2rem;
   }
 
   .post-grid {
@@ -69,8 +213,70 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   }
 
   @media (max-width: 760px) {
+    .home-hero,
+    .mission-board,
+    .current-course,
+    .systems-rigor {
+      grid-template-columns: 1fr;
+    }
+
+    .home-hero {
+      min-height: auto;
+    }
+
+    .hero-copy {
+      padding: 2.75rem 1.25rem 1.5rem;
+    }
+
+    .home-hero h1 {
+      font-size: clamp(2.85rem, 15vw, 4.5rem);
+    }
+
+    .mission-board > header {
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .mission-grid {
+      grid-template-columns: 1fr;
+    }
+
     .post-grid {
       grid-template-columns: 1fr;
+    }
+  }
+
+  :global(html[data-view='direct']) .home-hero {
+    min-height: auto;
+    background: transparent;
+    grid-template-columns: minmax(0, 1.2fr) minmax(20rem, 0.8fr);
+  }
+
+  :global(html[data-view='direct']) .home-hero h1 {
+    font-size: clamp(2.8rem, 6vw, 5rem);
+    text-transform: none;
+  }
+
+  :global(html[data-view='direct']) .mission-board {
+    grid-template-columns: 1fr;
+  }
+
+  :global(html[data-view='direct']) .mission-board > header {
+    border-right: 0;
+  }
+
+  :global(html[data-view='direct']) .mission-grid {
+    gap: 0.75rem;
+    padding: 0 2rem 2rem;
+  }
+
+  @media (max-width: 760px) {
+    :global(html[data-view='direct']) .home-hero {
+      grid-template-columns: 1fr;
+    }
+
+    :global(html[data-view='direct']) .mission-grid {
+      padding: 0 1rem 1rem;
     }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -80,6 +80,18 @@ body {
   line-height: 1.65;
 }
 
+.direct-only {
+  display: none !important;
+}
+
+html[data-view='direct'] .ops-only {
+  display: none !important;
+}
+
+html[data-view='direct'] .direct-only {
+  display: revert !important;
+}
+
 html[data-view='direct'] body {
   background:
     linear-gradient(rgba(28, 91, 97, 0.045) 1px, transparent 1px),


### PR DESCRIPTION
## Summary

- replace the shared AI-security identity with Small Screens / Big Worlds by Shawn Campbell
- build the approved immersive Ops homepage with an orbital focus map and mission board
- provide a compact Direct homepage using the same semantic content
- lead with mobile and product engineering while presenting games as an active learning trajectory
- keep AI as a development tool and security as an embedded engineering discipline

## Responsive behavior

- desktop Ops retains the orbital composition and reveals the mission board at the fold
- Direct mode converts spatial navigation into a conventional capability grid
- mobile converts the orbit into ordinary links and preserves the headline, actions, and following content without overflow

## Validation

- `npm run test:shell`
- `npm run test:view`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- rendered QA at 1440x1000 and 390x844 in Ops and Direct modes

Closes #90
Part of #86
