### PR TITLE
[#87] Add project Shipyard and editorial taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# ai-sec-research
+# Small Screens / Big Worlds
 
-Personal blog and research notes on AI security, red teaming, and agentic
-systems. Built with [Astro](https://astro.build) and deployed to GitHub Pages.
+Shawn Campbell's publication and portfolio for mobile engineering, React and
+React Native, frontend systems, AI-assisted development, game-development field
+notes, and security-conscious architecture. Built with [Astro](https://astro.build)
+and deployed to GitHub Pages.
 
 Live site: <https://sandkcampbell.com/>
 
@@ -27,8 +29,32 @@ description: "..."
 pubDate: 2026-05-13
 draft: true            # optional; defaults to false
 tags: ["..."]          # optional
+format: "flight-log"   # optional
 ---
 ```
+
+Supported formats:
+
+- `system-deep-dive` — long-form architecture and implementation analysis
+- `flight-log` — short experiments and progress reports
+- `postmortem` — decisions, failures, measurements, and corrections
+- `cross-system-test` — one feature or mechanic across frameworks or engines
+
+Existing posts without `format` remain valid and render as general field notes.
+
+## Editorial direction
+
+- 50% mobile and product engineering
+- 20% AI-assisted development
+- 20% game-development field logs
+- 10% security and systems rigor
+
+Recommended first sequence:
+
+1. Building the Same Feature in SwiftUI, Jetpack Compose, and React Native
+2. What AI Coding Agents Get Wrong About Mobile Apps
+3. Learning Godot as a Mobile Systems Engineer
+4. Offline-First Sync Without Lying to the User
 
 ## Presentation package
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "astro": "astro",
     "test:view": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/test-view-mode.mjs",
     "test:shell": "node scripts/test-publication-shell.mjs",
+    "test:editorial": "node scripts/test-projects-editorial.mjs",
     "test:lab": "node scripts/run-lab-tests.mjs"
   },
   "dependencies": {

--- a/scripts/test-projects-editorial.mjs
+++ b/scripts/test-projects-editorial.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [config, projects, blog, readme] = await Promise.all([
+  readFile(new URL('../src/content.config.ts', import.meta.url), 'utf8'),
+  readFile(new URL('../src/pages/projects/index.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/pages/blog/index.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../README.md', import.meta.url), 'utf8'),
+]);
+
+for (const format of [
+  'system-deep-dive',
+  'flight-log',
+  'postmortem',
+  'cross-system-test',
+]) {
+  assert.match(config, new RegExp(format));
+}
+
+assert.match(config, /optional\(\)/);
+assert.match(projects, /Native Mobile/);
+assert.match(projects, /React and React Native/);
+assert.match(projects, /Frontend and Product Systems/);
+assert.match(projects, /Game Lab/);
+assert.match(projects, /Under construction/);
+assert.match(blog, /Flight Log/);
+assert.match(blog, /System Deep Dives/);
+assert.match(readme, /50% mobile and product engineering/);
+
+console.log('projects and editorial tests passed');

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,7 @@ import ViewModeToggle from './ViewModeToggle.astro';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const links = [
   { href: `${base}/`, label: 'Home' },
-  { href: `${base}/#selected-work`, label: 'Projects', opsLabel: 'Shipyard' },
+  { href: `${base}/projects`, label: 'Projects', opsLabel: 'Shipyard' },
   { href: `${base}/blog`, label: 'Blog' },
   { href: `${base}/resume`, label: 'Resume' },
   { href: `${base}/about`, label: 'About' },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,12 @@ const blog = defineCollection({
     updatedDate: z.coerce.date().optional(),
     draft: z.boolean().default(false),
     tags: z.array(z.string()).default([]),
+    format: z.enum([
+      'system-deep-dive',
+      'flight-log',
+      'postmortem',
+      'cross-system-test',
+    ]).optional(),
   }),
 });
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,9 +9,16 @@ interface Props {
   updatedDate?: Date;
   tags?: string[];
   draft?: boolean;
+  format?: 'system-deep-dive' | 'flight-log' | 'postmortem' | 'cross-system-test';
 }
 
-const { title, description, pubDate, updatedDate, tags = [], draft = false } = Astro.props;
+const { title, description, pubDate, updatedDate, tags = [], draft = false, format } = Astro.props;
+const formatLabels = {
+  'system-deep-dive': 'System Deep Dive',
+  'flight-log': 'Flight Log',
+  postmortem: 'Postmortem',
+  'cross-system-test': 'Cross-System Test',
+};
 
 const dateFmt = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -24,7 +31,7 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
   <article class="post-shell">
     <header class="post-header panel">
       {draft && <p class="draft-banner">Draft - not yet published</p>}
-      <p class="kicker">Field Note</p>
+      <p class="kicker">{format ? formatLabels[format] : 'Field Note'}</p>
       <h1>{title}</h1>
       <p class="description">{description}</p>
       <p class="meta">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -13,15 +13,55 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
 });
+
+const formatLabels = {
+  'system-deep-dive': 'System Deep Dive',
+  'flight-log': 'Flight Log',
+  postmortem: 'Postmortem',
+  'cross-system-test': 'Cross-System Test',
+} as const;
+
+const formats = [
+  {
+    title: 'System Deep Dives',
+    detail: 'Long-form architecture, implementation, and engineering analysis.',
+  },
+  {
+    title: 'Flight Logs',
+    detail: 'Short experiments, progress reports, and practical field notes.',
+  },
+  {
+    title: 'Postmortems',
+    detail: 'Decisions, failures, measurements, and corrections.',
+  },
+  {
+    title: 'Cross-System Tests',
+    detail: 'The same feature or mechanic examined across frameworks and engines.',
+  },
+];
 ---
 
-<BaseLayout title="Blog — ai-sec-research" description="All posts">
-  <section class="blog-index panel">
-    <p class="kicker">Signal Archive</p>
-    <h1>Blog</h1>
+<BaseLayout title="Writing — Small Screens / Big Worlds" description="Mobile, AI-assisted development, game-development, and systems field notes.">
+  <section class="blog-index">
+    <p class="kicker ops-only">Flight Log / Signal Archive</p>
+    <p class="kicker direct-only">Writing</p>
+    <h1>
+      <span class="ops-only">Dispatches from the build</span>
+      <span class="direct-only">Technical articles and field notes</span>
+    </h1>
     <p class="muted">
-      Field notes, lab writeups, and practical analysis from AI security work.
+      Mobile and product engineering lead the archive. AI-assisted development,
+      game-development study, and systems-under-stress research round it out.
     </p>
+  </section>
+
+  <section class="format-grid" aria-label="Article formats">
+    {formats.map((format) => (
+      <article>
+        <h2>{format.title}</h2>
+        <p>{format.detail}</p>
+      </article>
+    ))}
   </section>
 
   {posts.length === 0 ? (
@@ -31,7 +71,11 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
       {posts.map((post) => (
         <a class="signal-card" href={`${base}/blog/${post.id}`}>
           <span class="signal-card__label">
-            {post.data.draft ? 'Draft' : 'Post'}
+            {post.data.draft
+              ? 'Draft'
+              : post.data.format
+                ? formatLabels[post.data.format]
+                : 'Field Note'}
           </span>
           <span class="signal-card__title">{post.data.title}</span>
           <time class="signal-card__meta" datetime={post.data.pubDate.toISOString()}>
@@ -46,8 +90,8 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
 
 <style>
   .blog-index {
-    margin-bottom: 1rem;
-    padding: clamp(1.25rem, 3vw, 2rem);
+    padding: clamp(2rem, 6vw, 4rem);
+    border-bottom: 1px solid var(--border);
   }
 
   .blog-index h1 {
@@ -62,5 +106,53 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
   .post-list {
     display: grid;
     gap: 0.9rem;
+    margin-top: 1rem;
+  }
+
+  .format-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border-bottom: 1px solid var(--border);
+  }
+
+  .format-grid article {
+    padding: 1.25rem;
+    border-right: 1px solid var(--border);
+  }
+
+  .format-grid article:last-child {
+    border-right: 0;
+  }
+
+  .format-grid h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+  }
+
+  .format-grid p {
+    margin: 0;
+    color: var(--fg-muted);
+    font-size: 0.84rem;
+  }
+
+  @media (max-width: 760px) {
+    .format-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .format-grid article:nth-child(2) {
+      border-right: 0;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .format-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .format-grid article {
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+    }
   }
 </style>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,203 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const areas = [
+  {
+    code: '01',
+    opsLabel: 'Native Mobile',
+    directLabel: 'Native Mobile',
+    status: 'Flight proven',
+    summary:
+      'iOS and Android systems built with Swift, Kotlin, Objective-C, Java, and C++, including offline workflows, sensors, connected devices, and mobile-to-cloud integration.',
+    evidence: ['Native architecture', 'Connected products', 'Offline behavior', 'Team leadership'],
+  },
+  {
+    code: '02',
+    opsLabel: 'Product Systems',
+    directLabel: 'React and React Native',
+    status: 'Flight proven',
+    summary:
+      'Cross-platform product engineering across React Native, TypeScript, React, GraphQL, APIs, design systems, and frontend delivery at team scale.',
+    evidence: ['React Native', 'TypeScript', 'GraphQL', 'Design systems'],
+  },
+  {
+    code: '03',
+    opsLabel: 'Interface Deck',
+    directLabel: 'Frontend and Product Systems',
+    status: 'Flight proven',
+    summary:
+      'Web interfaces and distributed product surfaces shaped by usability, performance, accessibility, operational constraints, and maintainable architecture.',
+    evidence: ['Frontend architecture', 'Product delivery', 'Accessibility', 'Distributed systems'],
+  },
+  {
+    code: '04',
+    opsLabel: 'Game Lab',
+    directLabel: 'Game Lab',
+    status: 'Under construction',
+    summary:
+      'A serious learning program in Godot and Unreal focused on gameplay loops, input, state, tools, mobile deployment, and AI-assisted prototyping.',
+    evidence: ['Godot', 'Unreal Engine', 'Gameplay systems', 'Learning in public'],
+  },
+];
+---
+
+<BaseLayout
+  title="Projects — Small Screens / Big Worlds"
+  description="Mobile, React, frontend, and game-development work by Shawn Campbell."
+>
+  <header class="projects-hero">
+    <p class="kicker ops-only">Shipyard / Systems Manifest</p>
+    <p class="kicker direct-only">Projects and Capabilities</p>
+    <h1>
+      <span class="ops-only">Systems under construction</span>
+      <span class="direct-only">Mobile, frontend, and game-development work</span>
+    </h1>
+    <p>
+      This index describes the work I can discuss accurately today. Detailed
+      case studies and playable experiments will replace broad capability
+      summaries as public artifacts are ready.
+    </p>
+  </header>
+
+  <section class="project-list" aria-label="Project areas">
+    {areas.map((area) => (
+      <article class="project-area">
+        <div class="project-area__code">{area.code}</div>
+        <div class="project-area__body">
+          <p class="project-area__status">{area.status}</p>
+          <h2>
+            <span class="ops-only">{area.opsLabel}</span>
+            <span class="direct-only">{area.directLabel}</span>
+          </h2>
+          <p>{area.summary}</p>
+          <ul>
+            {area.evidence.map((item) => <li>{item}</li>)}
+          </ul>
+        </div>
+      </article>
+    ))}
+  </section>
+
+  <aside class="case-study-note">
+    <p class="kicker ops-only">Docking Queue</p>
+    <p class="kicker direct-only">Case Study Standard</p>
+    <h2>Evidence before decoration.</h2>
+    <p>
+      Future entries will include role, constraints, decisions, implementation,
+      outcome, screenshots or playable evidence, and lessons learned. No invented
+      metrics and no inflated claims.
+    </p>
+  </aside>
+</BaseLayout>
+
+<style>
+  .projects-hero {
+    padding: clamp(2rem, 6vw, 4.5rem);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .projects-hero h1 {
+    max-width: 58rem;
+    margin: 0 0 1rem;
+    text-transform: uppercase;
+  }
+
+  .projects-hero > p:last-child {
+    max-width: 50rem;
+    color: var(--fg-muted);
+    font-size: 1.08rem;
+  }
+
+  .project-list {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .project-area {
+    display: grid;
+    grid-template-columns: 6rem minmax(0, 1fr);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .project-area:last-child {
+    border-bottom: 0;
+  }
+
+  .project-area__code {
+    padding: 1.5rem;
+    border-right: 1px solid var(--border);
+    color: var(--warning);
+    font: 700 1rem var(--font-mono);
+  }
+
+  .project-area__body {
+    padding: clamp(1.5rem, 4vw, 2.5rem);
+  }
+
+  .project-area__status {
+    color: var(--accent-strong);
+    font: 700 0.72rem var(--font-mono);
+    text-transform: uppercase;
+  }
+
+  .project-area h2 {
+    margin: 0 0 0.75rem;
+  }
+
+  .project-area__body > p:not(.project-area__status) {
+    max-width: 52rem;
+    color: var(--fg-muted);
+  }
+
+  .project-area ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 1.25rem 0 0;
+    padding: 0;
+  }
+
+  .project-area li {
+    border: 1px solid var(--border);
+    padding: 0.35rem 0.55rem;
+    color: var(--fg-muted);
+    font: 700 0.7rem var(--font-mono);
+    text-transform: uppercase;
+  }
+
+  .case-study-note {
+    padding: clamp(2rem, 6vw, 4rem);
+    background: rgba(228, 173, 84, 0.05);
+  }
+
+  .case-study-note h2 {
+    margin-top: 0;
+  }
+
+  .case-study-note > p:last-child {
+    max-width: 48rem;
+    color: var(--fg-muted);
+  }
+
+  :global(html[data-view='direct']) .projects-hero h1 {
+    text-transform: none;
+  }
+
+  :global(html[data-view='direct']) .project-area {
+    grid-template-columns: 1fr;
+  }
+
+  :global(html[data-view='direct']) .project-area__code {
+    display: none;
+  }
+
+  @media (max-width: 640px) {
+    .project-area {
+      grid-template-columns: 3.5rem minmax(0, 1fr);
+    }
+
+    .project-area__code {
+      padding: 1rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

- add a dedicated Shipyard / Projects route for native mobile, React Native, frontend systems, and Game Lab work
- add optional article formats without changing existing post frontmatter or URLs
- reframe the blog as Flight Log / Writing with four literal editorial formats
- document the editorial mix and first recommended article sequence
- keep project claims conservative and game-development status explicitly under construction

## Compatibility

- existing posts without `format` remain valid and render as Field Notes
- existing security articles stay in the same archive at the same URLs
- no project metrics, client outcomes, or game expertise were invented

## Validation

- `npm run test:editorial`
- `npm run test:shell`
- `npm run test:view`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- rendered QA for Direct projects at 1440x1000 and Ops blog at 390x844

Closes #87
Part of #86
