### PR TITLE
[#91] Reposition resume and About

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ai-sec-research-blog",
+  "name": "small-screens-big-worlds",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ai-sec-research-blog",
+      "name": "small-screens-big-worlds",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-sec-research-blog",
+  "name": "small-screens-big-worlds",
   "type": "module",
   "version": "0.0.1",
   "private": true,
@@ -12,6 +12,7 @@
     "test:view": "node --disable-warning=ExperimentalWarning --experimental-strip-types scripts/test-view-mode.mjs",
     "test:shell": "node scripts/test-publication-shell.mjs",
     "test:editorial": "node scripts/test-projects-editorial.mjs",
+    "test:profile": "node scripts/test-profile-repositioning.mjs",
     "test:lab": "node scripts/run-lab-tests.mjs"
   },
   "dependencies": {

--- a/scripts/test-profile-repositioning.mjs
+++ b/scripts/test-profile-repositioning.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [resume, about, footer, giscus, rss] = await Promise.all([
+  readFile(new URL('../src/pages/resume.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/pages/about.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/components/Footer.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/components/Giscus.astro', import.meta.url), 'utf8'),
+  readFile(new URL('../src/pages/rss.xml.js', import.meta.url), 'utf8'),
+]);
+
+assert.match(resume, /Mobile and Product Engineer/);
+assert.match(resume, /React Native/);
+assert.match(resume, /Game Development/);
+assert.match(resume, /Current learning focus/);
+assert.match(resume, /@media print/);
+assert.match(resume, /html\[data-view='direct'\]/);
+assert.match(about, /Small Screens \/ Big Worlds/);
+assert.match(about, /AI-assisted/);
+assert.match(about, /Godot and Unreal/);
+
+for (const source of [footer, giscus]) {
+  assert.match(source, /small_screens_big_worlds/);
+  assert.doesNotMatch(source, /ai_sec_research/);
+}
+
+assert.match(rss, /Small Screens \/ Big Worlds/);
+
+console.log('profile repositioning tests passed');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const year = new Date().getFullYear();
 <footer>
   <p>
     © {year} Shawn Campbell · Small Screens / Big Worlds ·
-    <a href="https://github.com/jaegerpicker/ai_sec_research">source</a> ·
+    <a href="https://github.com/jaegerpicker/small_screens_big_worlds">source</a> ·
     <a href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/rss.xml`}>rss</a>
   </p>
 </footer>

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -12,7 +12,7 @@ const commentsEnabled = true;
 
 {commentsEnabled && (
   <script src="https://giscus.app/client.js"
-        data-repo="jaegerpicker/ai_sec_research"
+        data-repo="jaegerpicker/small_screens_big_worlds"
         data-repo-id="R_kgDOScw3Gg"
         data-category="Announcements"
         data-category-id="DIC_kwDOScw3Gs4C9-dD"

--- a/src/content/blog/welcome.md
+++ b/src/content/blog/welcome.md
@@ -16,6 +16,6 @@ Two posts are currently in flight:
 - The Production Agent Attack Surface — what I've learned building agents in production and why it makes me nervous as a security engineer.
 - Supply Chain Attacks on AI Tooling: Lessons from Shai-Hulud — a field report on the npm worm that targeted ~/.claude/, and what I built in response.
 
-More to come. The source for this site lives at github.com/jaegerpicker/ai_sec_research.
+More to come. The source for this site lives at github.com/jaegerpicker/small_screens_big_worlds.
 
 Let's see how deep it goes!

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,18 +4,42 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
-<BaseLayout title="About — ai-sec-research" description="About Shawn Campbell and this site.">
-  <section class="about-panel panel">
-    <p class="kicker">Profile</p>
-    <h1>About</h1>
-    <p>
-      I'm Shawn Campbell, a security/software engineer working on AI red teaming
-      and the security of agentic systems. This site is where I publish writeups
-      from my personal AI red-team lab and notes on supply-chain and
-      agent-attack-surface work.
+<BaseLayout title="About — Small Screens / Big Worlds" description="About Shawn Campbell and Small Screens / Big Worlds.">
+  <section class="about-panel">
+    <p class="kicker ops-only">Origin Signal / Profile</p>
+    <p class="kicker direct-only">About</p>
+    <h1>Small Screens / Big Worlds</h1>
+    <p class="lead">
+      I'm Shawn Campbell, a mobile and product engineer, frontend architect,
+      and technical leader with 25 years of experience building software and
+      engineering teams.
     </p>
+    <p>
+      Native mobile, React and React Native, connected products, and frontend
+      systems are the foundation of my work. I'm now applying those habits to
+      game development in Godot and Unreal: learning in public, shipping
+      playable experiments, and documenting what transfers from product
+      engineering and what does not.
+    </p>
+    <p>
+      AI-assisted development is part of that process. I use coding agents and
+      generative tools to accelerate research, prototypes, testing, and creative
+      iteration, while keeping engineering judgment and art direction human.
+      Security remains embedded in the work through permissions, storage, trust
+      boundaries, threat modeling, and resilient architecture.
+    </p>
+    <aside>
+      <p class="kicker ops-only">Current Course</p>
+      <p class="kicker direct-only">Current Direction</p>
+      <p>
+        Build useful mobile and web products, develop real game-engine depth,
+        and publish technical work that is honest about both expertise and
+        learning.
+      </p>
+    </aside>
     <nav class="about-links" aria-label="Profile links">
       <a href="https://github.com/jaegerpicker">GitHub</a>
+      <a href={`${base}/projects`}>Projects</a>
       <a href={`${base}/blog`}>Blog</a>
       <a href={`${base}/resume`}>Resume</a>
     </nav>
@@ -24,7 +48,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 <style>
   .about-panel {
-    padding: clamp(1.25rem, 3vw, 2rem);
+    padding: clamp(2rem, 7vw, 5rem);
+    border-bottom: 1px solid var(--border);
   }
 
   .about-panel h1 {
@@ -32,8 +57,25 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   }
 
   .about-panel p {
-    max-width: 44rem;
+    max-width: 52rem;
     color: var(--fg-muted);
+  }
+
+  .about-panel .lead {
+    color: var(--fg);
+    font-size: clamp(1.15rem, 2.4vw, 1.5rem);
+  }
+
+  aside {
+    max-width: 52rem;
+    margin-top: 2rem;
+    border-left: 3px solid var(--warning);
+    background: rgba(228, 173, 84, 0.05);
+    padding: 1rem 1.25rem;
+  }
+
+  aside p:last-child {
+    margin-bottom: 0;
   }
 
   .about-links {

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -5,34 +5,34 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 const capabilities = [
   {
-    label: 'AI Threat Research',
+    label: 'Native Mobile Engineering',
     details:
-      'Agentic attack surface mapping, prompt-injection labs, tool-use risk analysis, and secure AI workflow review.',
+      'Swift, Kotlin, Objective-C, Java, C++, connected devices, offline workflows, and mobile-to-cloud architecture.',
   },
   {
-    label: 'Security Architecture',
+    label: 'React and React Native',
     details:
-      'Application security assessments, secure API design, threat modeling, GraphQL review, and cloud-native guardrails.',
+      'Cross-platform products, TypeScript, React, GraphQL, design systems, performance, and frontend delivery at team scale.',
   },
   {
-    label: 'Red-Team Methodology',
+    label: 'Frontend and Product Systems',
     details:
-      'Internal red-team exercises, proof-of-concept exploit development, secure code review, and attacker-informed remediation.',
-  },
-  {
-    label: 'Distributed Platforms',
-    details:
-      'IoT, smart-access, mobile, data pipeline, serverless, and event-driven systems across AWS and GCP environments.',
-  },
-  {
-    label: 'Systems Engineering',
-    details:
-      'Swift, Kotlin, C++, TypeScript, Go, Python, C#, Java, GraphQL, React, and mobile-to-cloud integration.',
+      'Accessible product interfaces, API integration, distributed workflows, and architecture shaped by operational constraints.',
   },
   {
     label: 'Engineering Leadership',
     details:
-      'Principal-level technical direction, team formation, standards, mentoring, cross-functional execution, and delivery discipline.',
+      'Principal-level technical direction, team formation, hiring, standards, mentoring, and cross-functional execution.',
+  },
+  {
+    label: 'Connected and Distributed Systems',
+    details:
+      'IoT, smart access, data pipelines, serverless platforms, event-driven systems, AWS, GCP, and backend services.',
+  },
+  {
+    label: 'Security and Systems Rigor',
+    details:
+      'Threat modeling, application security, red-team methodology, secure code review, trust boundaries, and resilient delivery.',
   },
 ];
 
@@ -156,55 +156,58 @@ const signals = [
 
 <BaseLayout
   title="Resume — Shawn Campbell"
-  description="Mission dossier for Shawn Campbell: AI security, secure systems architecture, red-team methodology, and engineering leadership."
+  description="Shawn Campbell: mobile and product engineer, frontend architect, React Native leader, and hands-on engineering leader."
 >
   <article class="resume-dossier">
     <section class="hero-panel">
       <div>
-        <p class="kicker">Mission Profile</p>
+        <p class="kicker ops-only">Crew File / Mission Profile</p>
+        <p class="kicker direct-only">Professional Profile</p>
         <h1>Shawn Campbell</h1>
         <p class="role-line">
-          AI security researcher, secure systems architect, red-team practitioner,
-          and hands-on engineering leader.
+          Mobile and Product Engineer, frontend architect, and hands-on
+          engineering leader.
         </p>
         <p class="mission-copy">
-          Shawn Campbell builds and reviews systems where software, agents,
-          devices, data, and teams intersect. His work centers on secure
-          foundations: AI threat research, application security, distributed
-          platforms, mobile and IoT depth, and leadership that turns risk into
-          clear engineering practice.
+          Shawn Campbell has spent 25 years building software, products, and
+          engineering teams. His strongest depth is in native mobile, React and
+          React Native, connected products, frontend systems, and technical
+          leadership. Security remains part of the engineering discipline, while
+          game development in Godot and Unreal is a current learning focus.
         </p>
         <ul class="badge-row" aria-label="Mission badges">
-          <li>AI Security</li>
-          <li>Red Team</li>
-          <li>Secure Systems</li>
+          <li>Native Mobile</li>
+          <li>React Native</li>
+          <li>Frontend Systems</li>
           <li>Engineering Leadership</li>
-          <li>Distributed Platforms</li>
+          <li>Connected Products</li>
         </ul>
       </div>
 
       <aside class="contact-panel" aria-label="Profile telemetry">
-        <p class="panel-label">Telemetry</p>
+        <p class="panel-label ops-only">Telemetry</p>
+        <p class="panel-label direct-only">Summary</p>
         <dl>
           <div>
             <dt>Operating Mode</dt>
-            <dd>Principal IC / technical lead / security partner</dd>
+            <dd>Principal IC / technical lead / engineering leader</dd>
           </div>
           <div>
             <dt>Primary Focus</dt>
-            <dd>Agentic AI security, appsec, mobile, IoT, cloud platforms</dd>
+            <dd>Native mobile, React Native, frontend, connected products</dd>
           </div>
           <div>
-            <dt>Signal</dt>
-            <dd>25 years building systems, teams, and security practices</dd>
+            <dt>Current learning focus</dt>
+            <dd>Game Development with Godot and Unreal Engine</dd>
           </div>
         </dl>
       </aside>
     </section>
 
     <section class="dossier-section" aria-labelledby="capabilities-heading">
-      <p class="kicker">Capabilities Matrix</p>
-      <h2 id="capabilities-heading">Security-First Engineering Surface</h2>
+      <p class="kicker ops-only">Capabilities Matrix</p>
+      <p class="kicker direct-only">Core Capabilities</p>
+      <h2 id="capabilities-heading">Mobile, Product, and Engineering Leadership</h2>
       <div class="capability-grid">
         {capabilities.map((capability) => (
           <article class="capability-card">
@@ -216,8 +219,12 @@ const signals = [
     </section>
 
     <section class="dossier-section" aria-labelledby="record-heading">
-      <p class="kicker">Operational Record</p>
-      <h2 id="record-heading">Recent Assignments</h2>
+      <p class="kicker ops-only">Operational Record</p>
+      <p class="kicker direct-only">Experience</p>
+      <h2 id="record-heading">
+        <span class="ops-only">Recent Assignments</span>
+        <span class="direct-only">Professional Experience</span>
+      </h2>
       <div class="timeline">
         {roles.map((role) => (
           <article class="role-card">
@@ -237,7 +244,8 @@ const signals = [
     </section>
 
     <section class="dossier-section" aria-labelledby="early-heading">
-      <p class="kicker">Early Systems Work</p>
+      <p class="kicker ops-only">Early Systems Work</p>
+      <p class="kicker direct-only">Earlier Experience</p>
       <h2 id="early-heading">Foundation Layer</h2>
       <ol class="early-list">
         {earlySystems.map((item) => <li>{item}</li>)}
@@ -245,8 +253,9 @@ const signals = [
     </section>
 
     <section class="dossier-section" aria-labelledby="signals-heading">
-      <p class="kicker">Selected Signals</p>
-      <h2 id="signals-heading">Research, Writing, and Public Artifacts</h2>
+      <p class="kicker ops-only">Selected Signals</p>
+      <p class="kicker direct-only">Selected Writing</p>
+      <h2 id="signals-heading">Writing, Research, and Public Artifacts</h2>
       <div class="signals-grid">
         {signals.map((signal) => (
           <a class="signal-card" href={signal.href}>
@@ -259,7 +268,8 @@ const signals = [
     </section>
 
     <section class="dossier-section contact-panel" aria-labelledby="links-heading">
-      <p class="kicker">Professional Links</p>
+      <p class="kicker ops-only">Professional Channels</p>
+      <p class="kicker direct-only">Links</p>
       <h2 id="links-heading">Public Channels</h2>
       <nav class="contact-links" aria-label="Professional links">
         <a href="https://www.linkedin.com/in/shawnmcampbell">LinkedIn</a>
@@ -569,6 +579,109 @@ const signals = [
     .capability-grid,
     .signals-grid {
       grid-template-columns: 1fr;
+    }
+  }
+
+  :global(html[data-view='direct']) .resume-dossier {
+    gap: 1rem;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  :global(html[data-view='direct']) .hero-panel,
+  :global(html[data-view='direct']) .dossier-section,
+  :global(html[data-view='direct']) .contact-panel,
+  :global(html[data-view='direct']) .capability-card,
+  :global(html[data-view='direct']) .role-card,
+  :global(html[data-view='direct']) .signal-card {
+    background: #fff;
+    box-shadow: none;
+  }
+
+  :global(html[data-view='direct']) .hero-panel::after {
+    display: none;
+  }
+
+  :global(html[data-view='direct']) .hero-panel {
+    grid-template-columns: minmax(0, 1fr) minmax(15rem, 0.32fr);
+  }
+
+  :global(html[data-view='direct']) h1 {
+    font-size: clamp(2.75rem, 6vw, 4.5rem);
+  }
+
+  :global(html[data-view='direct']) .role-line {
+    color: var(--fg);
+    font-weight: 700;
+  }
+
+  @media (max-width: 1100px) {
+    :global(html[data-view='direct']) .hero-panel {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media print {
+    :global(header),
+    :global(footer),
+    .signals-grid,
+    .contact-links {
+      display: none !important;
+    }
+
+    :global(html),
+    :global(body) {
+      background: #fff !important;
+      color: #111 !important;
+    }
+
+    :global(main) {
+      width: 100%;
+      padding: 0;
+    }
+
+    .resume-dossier {
+      display: block;
+      padding: 0;
+    }
+
+    .hero-panel,
+    .dossier-section,
+    .contact-panel,
+    .capability-card,
+    .role-card {
+      break-inside: avoid;
+      border-color: #bbb;
+      background: #fff !important;
+      box-shadow: none;
+    }
+
+    .hero-panel {
+      grid-template-columns: 1fr;
+    }
+
+    .hero-panel::after,
+    .ops-only {
+      display: none !important;
+    }
+
+    .direct-only {
+      display: revert !important;
+    }
+
+    h1,
+    h2,
+    h3,
+    .role-line,
+    .contact-panel dt,
+    .contact-panel dd {
+      color: #111 !important;
+    }
+
+    p,
+    li,
+    .role-header span {
+      color: #333 !important;
     }
   }
 </style>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -6,8 +6,8 @@ export async function GET(context) {
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
   return rss({
-    title: 'ai-sec-research',
-    description: 'Notes on AI security, red teaming, and agent attack surface.',
+    title: 'Small Screens / Big Worlds',
+    description: 'Mobile engineering, AI-assisted development, game-development, and systems field notes.',
     site: context.site,
     items: posts.map((post) => ({
       title: post.data.title,

--- a/src/pages/talks/summit-owasp-llm-top-10.astro
+++ b/src/pages/talks/summit-owasp-llm-top-10.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const repoBase = 'https://github.com/jaegerpicker/ai_sec_research/blob/main';
+const repoBase = 'https://github.com/jaegerpicker/small_screens_big_worlds/blob/main';
 
 const slides = [
   {
@@ -283,7 +283,7 @@ const slides = [
     </p>
     <nav aria-label="Talk resources">
       <a href={`${base}/talks/summit-owasp-llm-top-10`}>Public talk page</a>
-      <a href="https://github.com/jaegerpicker/ai_sec_research/tree/main/talks/summit-owasp-llm-top-10">Repo materials</a>
+      <a href="https://github.com/jaegerpicker/small_screens_big_worlds/tree/main/talks/summit-owasp-llm-top-10">Repo materials</a>
     </nav>
   </section>
 


### PR DESCRIPTION
## Summary

- reposition the resume around native mobile, React Native, frontend systems, connected products, and engineering leadership
- retain security as an embedded engineering discipline and identify game development as a current learning focus
- provide Crew File terminology in Ops and a conventional recruiter-facing presentation in Direct
- rewrite About around Small Screens / Big Worlds, AI-assisted development, and the Godot/Unreal learning trajectory
- add print rules that remove site chrome and decorative effects from the resume
- update active source, Giscus, RSS, talk, and package references for the renamed repository

## Validation

- `npm run test:profile`
- `npm run test:editorial`
- `npm run test:shell`
- `npm run test:view`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- Direct resume QA at 1440x1000 and 390x844
- Ops About QA at 1440x1000
- print stylesheet review for navigation suppression, white backgrounds, and break avoidance

Closes #91
Part of #86
